### PR TITLE
Cutlass offload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *.so
 
 build*
+!build.py
 
 *.ll
 .npm

--- a/build.py
+++ b/build.py
@@ -173,6 +173,7 @@ def debug_dump_script(mod, name, args):
         return
     dump_path = os.path.join(args.artifact_path, "debug", name)
     with open(dump_path, "w") as outfile:
+        # Remove runtime modules from external codegen so that the IR module can be printed.
         mod = mod.without_attr("external_mods").without_attr("const_name_to_constant")
         outfile.write(mod.script(show_meta=True))
     print(f"Dump mod to {dump_path}")

--- a/build.py
+++ b/build.py
@@ -7,19 +7,26 @@ from typing import List
 import tvm
 import tvm.testing
 from tvm import relax
+from tvm.relax.backend.pattern_registry import get_pattern
 
 import mlc_llm
 from mlc_llm import utils
 from mlc_llm.relax_model import gpt_neox, llama
+from mlc_llm.transform import rewrite_attention
 
 
 def _parse_args():
     args = argparse.ArgumentParser()
     utils.argparse_add_common(args)
     args.add_argument("--quantization-sym", action="store_true", default=False)
-    args.add_argument("--quantization-mode", type=str, choices=["int4", "int3", "fp4"], default="int4")
-    args.add_argument("--quantization-storage-nbit", type=int, choices=[32, 16], default=32)
+    args.add_argument(
+        "--quantization-mode", type=str, choices=["int4", "int3", "fp4"], default="int4"
+    )
+    args.add_argument(
+        "--quantization-storage-nbit", type=int, choices=[32, 16], default=32
+    )
     args.add_argument("--no-quantize", action="store_true", default=False)
+    args.add_argument("--cutlass-offload", action="store_true", default=False)
     args.add_argument("--max-seq-len", type=int, default=-1)
     args.add_argument("--target", type=str, default="auto")
     args.add_argument("--db-path", type=str, default="log_db/")
@@ -34,8 +41,10 @@ def _parse_args():
     args.add_argument("--debug-load-script", action="store_true", default=False)
 
     args.add_argument(
-        "--llvm-mingw", type=str, default="",
-        help="/path/to/llvm-mingw-root, use llvm-mingw to cross compile to windows"
+        "--llvm-mingw",
+        type=str,
+        default="",
+        help="/path/to/llvm-mingw-root, use llvm-mingw to cross compile to windows",
     )
     args.add_argument("--system-lib", action="store_true", default=False)
 
@@ -64,7 +73,7 @@ def _parse_args():
         parsed.target_kind = "webgpu"
         parsed.lib_format = "wasm"
     elif parsed.target.startswith("iphone"):
-        from tvm.contrib import xcode, cc
+        from tvm.contrib import cc, xcode
 
         # override
         @tvm.register_func("tvm_callback_metal_compile")
@@ -118,14 +127,17 @@ def _parse_args():
         parsed.target_kind = parsed.target.kind.default_keys[0]
     elif parsed.target == "metal_x86_64":
         from tvm.contrib import xcode
+
         parsed.target = tvm.target.Target(
-            tvm.target.Target({
-                "kind": "metal",
-                "max_threads_per_block": 256,
-                "max_shared_memory_per_block": 32768,
-                "thread_warp_size": 1,
-            }),
-            host="llvm -mtriple=x86_64-apple-darwin"
+            tvm.target.Target(
+                {
+                    "kind": "metal",
+                    "max_threads_per_block": 256,
+                    "max_shared_memory_per_block": 32768,
+                    "thread_warp_size": 1,
+                }
+            ),
+            host="llvm -mtriple=x86_64-apple-darwin",
         )
         parsed.target_kind = "metal_x86_64"
         parsed.export_kwargs = {
@@ -141,14 +153,14 @@ def _parse_args():
     # use mingw to cross compile windows
     if parsed.llvm_mingw != "":
         from tvm.contrib.cc import cross_compiler
+
         parsed.export_kwargs = {
             "fcompile": cross_compiler(
                 os.path.join(parsed.llvm_mingw, "bin", "x86_64-w64-mingw32-clang++"),
-                output_format="dll"
+                output_format="dll",
             ),
         }
-        parsed.target = parsed.target.with_host(
-            "llvm -mtriple=x86_64-w64-windows-gnu")
+        parsed.target = parsed.target.with_host("llvm -mtriple=x86_64-w64-windows-gnu")
         parsed.lib_format = "dll"
 
     utils.argparse_postproc_common(parsed)
@@ -161,6 +173,7 @@ def debug_dump_script(mod, name, args):
         return
     dump_path = os.path.join(args.artifact_path, "debug", name)
     with open(dump_path, "w") as outfile:
+        mod = mod.without_attr("external_mods").without_attr("const_name_to_constant")
         outfile.write(mod.script(show_meta=True))
     print(f"Dump mod to {dump_path}")
 
@@ -206,6 +219,19 @@ def mod_transform_before_build(
             storage_nbit=args.quantization_storage_nbit,
             dtype=args.dtype,
         )(mod)
+    if args.target_kind == "cuda" and args.cutlass_offload:
+        from tvm.relax.backend.contrib.cutlass import partition_for_cutlass
+
+        debug_dump_script(mod, "mod_before_cutlass.py", args)
+        mod = partition_for_cutlass(mod)
+        debug_dump_script(mod, "mod_after_cutlass_partition.py", args)
+        codegen_pass = relax.transform.RunCodegen(
+            {"cutlass": {"sm": 80, "find_first_valid": False}},
+            entry_functions=model_names,
+        )
+        mod = codegen_pass(mod)
+        debug_dump_script(mod, "mod_after_cutlass_codegen.py", args)
+
     mod = mlc_llm.transform.FuseTransposeMatmul()(mod)
 
     mod = relax.pipeline.get_pipeline()(mod)
@@ -243,13 +269,11 @@ def build(mod_deploy: tvm.IRModule, args: argparse.Namespace) -> None:
 
     output_filename = f"{args.model}_{target_kind}_{args.dtype}.{args.lib_format}"
 
-
     debug_dump_shader(ex, f"{args.model}_{target_kind}_{args.dtype}", args)
     lib_path = os.path.join(args.artifact_path, output_filename)
-    ex.export_library(
-        lib_path, **args.export_kwargs
-    )
+    ex.export_library(lib_path, **args.export_kwargs)
     print(f"Finish exporting to {lib_path}")
+
 
 if __name__ == "__main__":
     ARGS = _parse_args()

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -308,16 +308,10 @@ class LlamaAttention(nn.Module):
             (bsz, tvm.tir.IntImm("int64", 1), q_len, kv_seq_len),
         )
         
-        attn_weights = nn.emit(maximum(attn_weights, relax.const(tvm.tir.min_value(attn_weights.struct_info.dtype).value, attn_weights.struct_info.dtype)))
-        attn_weights = nn.emit(relax.op.minimum(attn_weights, attention_mask))
+        attn_weights = nn.emit(relax.op.add(attn_weights, attention_mask))
 
 
-        # upcast attention to fp32
-        if attn_weights.struct_info.dtype != "float32":
-            attn_weights = astype(attn_weights, "float32")
         attn_weights = nn.emit(softmax(attn_weights, axis=-1))
-        if attn_weights.struct_info.dtype != query_states.struct_info.dtype:
-            attn_weights = astype(attn_weights, query_states.struct_info.dtype)
         attn_output = nn.emit(matmul(attn_weights, value_states))
 
         tvm.ir.assert_structural_equal(
@@ -399,7 +393,7 @@ def _make_causal_mask(input_ids_shape, dtype, src_len):
         return te.compute(
             (tgt_len, tgt_len),
             lambda i, j: tvm.tir.Select(
-                j > i, tvm.tir.min_value(dtype), tvm.tir.max_value(dtype)
+                j > i, tvm.tir.min_value(dtype), tvm.tir.FloatImm(dtype, 0)
             ),
             name="make_diag_mask_te",
         )
@@ -413,7 +407,7 @@ def _make_causal_mask(input_ids_shape, dtype, src_len):
         return te.compute(
             (bsz, 1, tgt_len, src_len),
             lambda b, _, i, j: te.if_then_else(
-                j < src_len - tgt_len, tvm.tir.max_value(dtype), x[b, _, i, j - (src_len - tgt_len)]
+                j < src_len - tgt_len, tvm.tir.FloatImm(dtype, 0), x[b, _, i, j - (src_len - tgt_len)]
             ),
             name="concat_te",
         )
@@ -446,7 +440,7 @@ class LlamaModel(nn.Module):
             # Get src_len from input parameters
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
             bsz, tgt_len = input_shape
-            combined_attention_mask = nn.emit(relax.op.full((bsz, 1, tgt_len, src_len), relax.const(tvm.tir.max_value(dtype).value, dtype), dtype))
+            combined_attention_mask = nn.emit(relax.op.full((bsz, 1, tgt_len, src_len), relax.const(0, dtype), dtype))
         return combined_attention_mask
 
     def forward(

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -2,3 +2,4 @@ from .dispatch_tir_operator import DispatchTIROperator
 from .quantization import GroupQuantize
 from .transpose_matmul import FuseTransposeMatmul
 from .decode_matmul_ewise import FuseDecodeMatmulEwise
+from .rewrite_attention import rewrite_attention

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -1,0 +1,28 @@
+from tvm.relax.dpl import PatternContext, is_const, is_op, rewrite_call, wildcard
+from tvm.script import relax as R
+
+
+def rewrite_attention(f):
+    Q = wildcard()
+    K = wildcard()
+    V = wildcard()
+    bias = wildcard()
+
+    Q_BNSH = is_op("relax.permute_dims")(Q)
+    K_BNSH = is_op("relax.permute_dims")(K)
+    V_BNSH = is_op("relax.permute_dims")(V)
+
+    K_BNSH_T = is_op("relax.permute_dims")(K_BNSH)
+
+    matmul1 = is_op("relax.matmul")(Q_BNSH, K_BNSH_T)
+    divide = is_op("relax.divide")(matmul1, is_const())
+    with_bias = is_op("relax.add")(divide, bias)
+    softmax = is_op("relax.nn.softmax")(with_bias)
+    matmul2 = is_op("relax.matmul")(softmax, V_BNSH)
+
+    pattern = is_op("relax.permute_dims")(matmul2)
+
+    def callback(_, matchings):
+        return R.nn.attention(matchings[Q], matchings[K], matchings[V], matchings[bias])
+
+    return rewrite_call(pattern, callback, f)

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -45,9 +45,10 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
         args.conv_template = "vicuna_v1.1"
 
     elif args.model.startswith("dolly-") or args.model.startswith("stablelm-"):
-        from mlc_llm.relax_model import (  # pylint: disable=import-outside-toplevel
+        from mlc_llm.relax_model import (
             gpt_neox,
-        )
+        )  # pylint: disable=import-outside-toplevel
+
         if args.model.startswith("dolly-"):
             args.conv_template = "dolly"
         elif args.model.startswith("stablelm-"):
@@ -83,6 +84,13 @@ def split_transform_deploy_mod(
         mod_transform
     )
     mod_deploy = relax.transform.DeadCodeElimination(model_names)(mod_deploy)
+
+    mod_deploy = mod_deploy.with_attrs(
+        {
+            "external_mods": mod.get_attr("external_mods"),
+            "const_name_to_constant": mod.get_attr("const_name_to_constant"),
+        }
+    )
 
     return mod_transform, mod_deploy
 

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -85,6 +85,7 @@ def split_transform_deploy_mod(
     )
     mod_deploy = relax.transform.DeadCodeElimination(model_names)(mod_deploy)
 
+    # Copy the runtime module from external codegen
     mod_deploy = mod_deploy.with_attrs(
         {
             "external_mods": mod.get_attr("external_mods"),


### PR DESCRIPTION
This PR adds a flag to enable cutlass offloading. Currently it only offloads matmul, including transposed matmul and matmul with bias. 

While there is a rewrite function to convert matmul-softmax-matmul to attention op, it's not used current, as the cutlass codegen doesn't support attention with dynamic shape yet.

With cutlass kernel tunning enabled, the resulted model is about twice as fast as the PyTorch version on a10g based on the benchmark script `tests/benchmark.py`.

This PR depends on https://github.com/mlc-ai/relax/pull/212.

<details>
<summary>Performance comparison to PyTorch</summary>

```
> python3 tests/benchmark.py --max-gen-len=256
=== Input 1 ===
...
   - # input token: 40
   - # output token: 7
   - process time: 1.406 s
=== Input 2 ===
...
   - # input token: 182
   - # output token: 82
   - process time: 5.971 s

> python3 tests/benchmark.py --max-gen-len=256 --run-torch-model
=== Input 1 ===
...
   - # input token: 40
   - # output token: 7
   - process time: 2.829 s
=== Input 2 ===
...
   - # input token: 182
   - # output token: 82
   - process time: 11.666 s
```
</details>

cc @sunggg