### PR TITLE
Update Benchmark Script

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,45 +1,69 @@
 import torch
 import argparse, os, time
 import tvm
-from mlc_llm.conversation import SeparatorStyle, conv_templates
+from mlc_llm.conversation import SeparatorStyle, conv_templates, compute_skip_echo_len
 from mlc_llm import utils
 from utils import get_tokenizer, get_pytorch_model, get_tvm_model, sample_top_p
+import numpy as np
 
-torch_device = torch_device = torch.device(
-    "cuda:0" if torch.cuda.is_available() else "cpu"
-)
+
+class Colors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+# NOTE: "all" is currently not supported due to GPU OOM issue in creating multiple model wrappers.
+BENCHMARK_MODES = ["tvm", "torch-eager", "torch-inductor"]
 
 
 def _parse_args():
     args = argparse.ArgumentParser()
     utils.argparse_add_common(args)
     args.add_argument("--device-name", type=str, default="auto")
-    args.add_argument("--debug-dump", action="store_true", default=False)
     args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument("--max-gen-len", type=int, default=2048)
-    args.add_argument("--run-torch-model", action="store_true", default=False)
+    args.add_argument(
+        "--benchmark-mode",
+        type=str,
+        choices=BENCHMARK_MODES,
+        default=BENCHMARK_MODES[0],
+    )
+    args.add_argument("--num-warm-up", type=int, default=5)
+    args.add_argument("--num-measurements", type=int, default=10)
+    args.add_argument("--num-input-tokens", type=int, default=32)
+    args.add_argument("--num-output-tokens", type=int, default=32)
+
     parsed = args.parse_args()
+
     parsed.model_path = os.path.join(parsed.artifact_path, "models", parsed.model)
     parsed.artifact_path = os.path.join(
         parsed.artifact_path,
         parsed.model,
         parsed.dtype,
     )
-
-    if parsed.device_name == "auto":
-        if tvm.cuda().exist:
-            parsed.device_name = "cuda"
-        elif tvm.metal().exist:
-            parsed.device_name = "metal"
-        else:
-            raise ValueError("Cannot auto deduce device-name, please set it")
+    utils.argparse_postproc_common(parsed)
     return parsed
 
 
 class ModelWrapper:
-    def __init__(self, tokenizer, max_gen_len):
+    def __init__(self, tokenizer, max_gen_len, conv_template):
+        self.name = None
         self.tokenizer = tokenizer
         self.max_gen_len = max_gen_len
+        self.conv_template = conv_template
+
+    def sync(self):
+        assert 0, "Not intended to call directly"
+
+    def benchmark_core(self, num_input_tokens, num_output_tokens):
+        assert 0, "Not intended to call directly"
 
     def generate(
         self,
@@ -48,60 +72,154 @@ class ModelWrapper:
         top_p: float = 0.95,
         stream_interval: int = 2,
         stop_str: str = None,
-        add_bos=True,
     ):
-        assert 0, "Need to implement"
+        assert 0, "Not intended to call directly"
 
 
+# TODO: Reset kv cache
 class TvmModelWrapper(ModelWrapper):
     def __init__(
-        self, tokenizer, max_gen_len, artifact_path, model, device_name, dtype
+        self,
+        tokenizer,
+        max_gen_len,
+        conv_template,
+        artifact_path,
+        model_name,
+        dtype,
+        tvm_device,
+        torch_device=("cuda" if torch.cuda.is_available() else "cpu"),
     ):
-        super().__init__(tokenizer, max_gen_len)
-        self.device_name = device_name
-        self.model = get_tvm_model(artifact_path, model, device_name, dtype)
+        super().__init__(tokenizer, max_gen_len, conv_template)
+        self.name = "tvm_model_wrapper"
+        self.artifact_path = artifact_path
+        self.model_name = model_name
+        self.dtype = dtype
+        self.tvm_device = tvm.device(tvm_device)
+        self.torch_device = torch.device(torch_device)
+        self.model = get_tvm_model(
+            self.artifact_path, self.model_name, self.tvm_device, tvm_device, self.dtype
+        )
+
+    def sync(self):
+        if self.torch_device.type == "cuda":
+            torch.cuda.synchronize()
+
+        if str(self.tvm_device) != "cpu":
+            self.tvm_device.sync()
+
+    def benchmark_core(self, num_input_tokens, num_output_tokens):
+        total_len = num_input_tokens + num_output_tokens
+        tokens = (
+            torch.full((1, total_len), self.tokenizer.pad_token_id)
+            .to(torch.int32)
+            .to(self.torch_device)
+        )
+
+        start_pos = num_input_tokens
+        for cur_pos in range(start_pos, total_len):
+            if cur_pos == start_pos:
+                # TODO: switch to the below when Eric's PR is merged.
+                #    tok = tvm.nd.from_dlpack(tokens[:, :cur_pos])
+                tok = tvm.nd.array(tokens[:, :cur_pos].numpy(), self.tvm_device)
+                logits = self.model(tok)
+            else:
+                # TODO: switch to the below when Eric's PR is merged.
+                #    tok = tvm.nd.from_dlpack(tokens[:, cur_pos - 1 : cur_pos])
+                tok = tvm.nd.array(
+                    tokens[:, cur_pos - 1 : cur_pos].numpy(), self.tvm_device
+                )
+                logits = self.model(tok)
+
+            # NOTE:
+            # There are three methods to work with torch ops.
+            # Method 1: tvm GPU -> torch GPU
+            #    logits = torch.from_dlpack(logits)
+            # Method 2: tvm GPU-> tvm CPU -> torch CPU
+            #    logits = tvm.nd.array(logits.numpy(), tvm.cpu())
+            #    logits = torch.from_dlpack(logits)
+            # Method 3: tvm GPU -> numpy CPU -> torch CPU
+            #    logits = torch.from_numpy(logits.numpy())
+            #
+            # For logits of [1,1,32k] = 128KB (our case), conversion on GPU (Method1) takes ~1sec,
+            # which could be non-neglibile for short response.
+            # However, conversion on CPU (Method 2&3) is very cheap even with the data copy from GPU to CPU.
+            # Rather than addressing this issue, we choose Method3 by default for now.
+
+            if str(self.torch_device) == "cpu":
+                logits = torch.from_numpy(logits.numpy())
+            else:
+                logits = torch.from_dlpack(logits)
+
+            logits = logits[:, -1, :]
+            # Use greedy
+            next_token = torch.argmax(logits, dim=-1)
+            next_token = next_token.reshape(-1)
+            tokens[:, cur_pos] = next_token
 
     def generate(
         self,
         prompt_tokens,
-        prompt_len,
         temperature: float = 0.8,
         top_p: float = 0.95,
         stream_interval: int = 2,
         stop_str: str = None,
-        add_bos=True,
     ):
-        total_len = self.max_gen_len + len(prompt_tokens)
+        prompt_len = len(prompt_tokens)
+        total_len = self.max_gen_len + prompt_len
         # TODO: Replace Torch ops to TVM
-        # Issue 1: `tokens` requires in-place update
+        # Issue 1: `tokens` requires in-place update.
+        # Issue 2: p-sampling use random generator which might have side effect.
         tokens = (
             torch.full((1, total_len), self.tokenizer.pad_token_id)
             .to(torch.int32)
-            .to(torch_device)
+            .to(self.torch_device)
         )
 
-        tokens[0, : len(prompt_tokens)] = (
-            torch.tensor(prompt_tokens).to(torch.int32).to(torch_device)
+        tokens[0, :prompt_len] = (
+            torch.tensor(prompt_tokens).to(torch.int32).to(self.torch_device)
         )
 
-        start_pos = len(prompt_tokens)
+        start_pos = prompt_len
         for cur_pos in range(start_pos, total_len):
             if cur_pos == start_pos:
-                tok = tvm.nd.from_dlpack(tokens[:, :cur_pos])
+                # TODO: switch to the below when Eric's PR is merged.
+                #    tok = tvm.nd.from_dlpack(tokens[:, :cur_pos])
+                tok = tvm.nd.array(tokens[:, :cur_pos].numpy(), self.tvm_device)
                 logits = self.model(tok)
             else:
-                tok = tvm.nd.from_dlpack(tokens[:, cur_pos - 1 : cur_pos])
+                # TODO: switch to the below when Eric's PR is merged.
+                #    tok = tvm.nd.from_dlpack(tokens[:, cur_pos - 1 : cur_pos])
+                tok = tvm.nd.array(
+                    tokens[:, cur_pos - 1 : cur_pos].numpy(), self.tvm_device
+                )
                 logits = self.model(tok)
 
-            logits = torch.from_dlpack(logits)
+            # NOTE:
+            # There are three methods to work with torch ops.
+            # Method 1: tvm GPU -> torch GPU
+            #    logits = torch.from_dlpack(logits)
+            # Method 2: tvm GPU-> tvm CPU -> torch CPU
+            #    logits = tvm.nd.array(logits.numpy(), tvm.cpu())
+            #    logits = torch.from_dlpack(logits)
+            # Method 3: tvm GPU -> numpy CPU -> torch CPU
+            #    logits = torch.from_numpy(logits.numpy())
+            #
+            # For logits of [1,1,32k] = 128KB (our case), conversion on GPU (Method1) takes ~1sec,
+            # which could be non-neglibile for short response.
+            # However, conversion on CPU (Method 2&3) is very cheap even with the data copy from GPU to CPU.
+            # Rather than addressing this issue, we choose Method3 by default for now.
+
+            if str(self.torch_device) == "cpu":
+                logits = torch.from_numpy(logits.numpy())
+            else:
+                logits = torch.from_dlpack(logits)
+
             logits = logits[:, -1, :]
             if temperature > 0:
-                probs = torch.softmax(
-                    (logits / temperature).to(torch.float32), dim=-1
-                ).to(torch_device)
+                probs = torch.softmax((logits / temperature).to(torch.float32), dim=-1)
                 next_token = sample_top_p(probs, top_p)
             else:
-                next_token = torch.argmax(logits, dim=-1).to(torch_device)
+                next_token = torch.argmax(logits, dim=-1)
             next_token = next_token.reshape(-1)
 
             tokens[:, cur_pos] = next_token
@@ -110,7 +228,6 @@ class TvmModelWrapper(ModelWrapper):
 
             i = cur_pos - start_pos
             if i % stream_interval == 0 or i == self.max_gen_len - 1 or stopped:
-                # TODO: Parallelize decoding
                 output = tokens[0, : cur_pos + 1]
                 output = self.tokenizer.decode(output, skip_special_tokens=True)
                 pos = output.rfind(stop_str, prompt_len)
@@ -124,49 +241,83 @@ class TvmModelWrapper(ModelWrapper):
 
 
 class TorchModelWrapper(ModelWrapper):
-    def __init__(self, tokenizer, max_gen_len, model_path, dtype):
-        super().__init__(tokenizer, max_gen_len)
-        self.model = get_pytorch_model(model_path, torch_device, dtype)
+    def __init__(
+        self,
+        tokenizer,
+        max_gen_len,
+        conv_template,
+        model_path,
+        dtype,
+        torch_mode,
+        torch_device=("cuda" if torch.cuda.is_available() else "cpu"),
+    ):
+        super().__init__(tokenizer, max_gen_len, conv_template)
+        self.name = f"torch_{torch_mode}_model_wrapper"
+        self.torch_device = torch.device(torch_device)
+        self.model_path = model_path
+        self.dtype = dtype
+        self.torch_mode = torch_mode
+        model = get_pytorch_model(
+            self.model_path, self.torch_device, self.dtype, use_cache=True
+        )
+        self.model = torch.compile(model, backend=self.torch_mode, dynamic=True)
+
+    def sync(self):
+        if self.torch_device.type == "cuda":
+            torch.cuda.synchronize()
+
+    def benchmark_core(self, num_input_tokens, num_output_tokens):
+        total_len = num_input_tokens + num_output_tokens
+        tokens = (
+            torch.full((1, total_len), self.tokenizer.pad_token_id)
+            .to(torch.int32)
+            .to(self.torch_device)
+        )
+
+        for cur_pos in range(num_input_tokens, total_len):
+            logits = self.model(tokens[:, :cur_pos])
+            logits = logits[:, -1, :]
+            # Use greedy
+            next_token = torch.argmax(logits, dim=-1)
+            next_token = next_token.reshape(-1)
+            tokens[:, cur_pos] = next_token
 
     def generate(
         self,
         prompt_tokens,
-        prompt_len,
         temperature: float = 0.8,
         top_p: float = 0.95,
         stream_interval: int = 2,
         stop_str: str = None,
-        add_bos=True,
     ):
-        total_len = self.max_gen_len + len(prompt_tokens)
+        prompt_len = len(prompt_tokens)
+        total_len = self.max_gen_len + prompt_len
         tokens = (
             torch.full((1, total_len), self.tokenizer.pad_token_id)
             .to(torch.int32)
-            .to(torch_device)
+            .to(self.torch_device)
         )
-        tokens[0, : len(prompt_tokens)] = (
-            torch.tensor(prompt_tokens).to(torch.int32).to(torch_device)
-        )
-        start_pos = len(prompt_tokens)
+        tokens[0, :prompt_len] = torch.tensor(prompt_tokens).to(torch.int32)
+        start_pos = prompt_len
+
         for cur_pos in range(start_pos, total_len):
             logits = self.model(tokens[:, :cur_pos])
             logits = logits[:, -1, :]
             if temperature > 0:
-                probs = torch.softmax(
-                    (logits / temperature).to(torch.float32), dim=-1
-                ).to(torch_device)
+                probs = torch.softmax((logits / temperature).to(torch.float32), dim=-1)
                 next_token = sample_top_p(probs, top_p)
             else:
-                next_token = torch.argmax(logits, dim=-1).to(torch_device)
+                next_token = torch.argmax(logits, dim=-1)
             next_token = next_token.reshape(-1)
             tokens[:, cur_pos] = next_token
-            # the following code assumes bsz == 1
+
             stopped = next_token[0] == self.tokenizer.eos_token_id
 
             i = cur_pos - start_pos
             if i % stream_interval == 0 or i == self.max_gen_len - 1 or stopped:
-                output = tokens[0, : cur_pos + 1]
-                output = self.tokenizer.decode(output, skip_special_tokens=True)
+                output = self.tokenizer.decode(
+                    tokens[0, : cur_pos + 1], skip_special_tokens=True
+                )
                 pos = output.rfind(stop_str, prompt_len)
                 if pos != -1:
                     output = output[:pos]
@@ -176,78 +327,160 @@ class TorchModelWrapper(ModelWrapper):
                 break
 
 
-def chat(model_wrapper, user_inps):
-    conv = conv_templates["vicuna_v1.1"].copy()
-    add_bos = True
+# Benchmark single-round conv
+def benchmark_e2e_chat(model_wrapper, prompt, enable_print=False):
+    conv = conv_templates[model_wrapper.conv_template].copy()
+    keep_first_token = True
 
-    for iid, inp in enumerate(user_inps):
-        conv.append_message(conv.roles[0], inp)
-        conv.append_message(conv.roles[1], None)
-        # TODO: Torch does not work with the following function for multi-round conv.
-        #       Check this w/ authors.
-        # prompt = conv.get_prompt_unprocessed()
-        prompt = conv.get_prompt()
+    conv.append_message(conv.roles[0], prompt)
+    conv.append_message(conv.roles[1], None)
+    prompt = conv.get_prompt()
 
-        print(f"=== Input {iid+1} ===")
-        print(f"{conv.roles[0]}: {inp}", flush=True)
-        print(f"{conv.roles[1]}: ", end="", flush=True)
+    model_wrapper.sync()
+    t0 = time.time()
+    prompt_tokens = model_wrapper.tokenizer.encode(prompt)
+    if not keep_first_token:
+        prompt_tokens = prompt_tokens[1:]
 
-        t0 = time.time()
-        prompt_tokens = model_wrapper.tokenizer.encode(prompt)
-        if not add_bos:
-            prompt_tokens = prompt_tokens[1:]
+    pre = 0
+    skip_echo_len = compute_skip_echo_len(model_wrapper.conv_template, conv, prompt)
+    outputs = None
+    for outputs in model_wrapper.generate(
+        prompt_tokens,
+        temperature=0,  # Use greedy to make it deterministic for benchmarking
+        stop_str=conv.sep if conv.sep_style == SeparatorStyle.SINGLE else conv.sep2,
+        # stream_interval=2048,  # To output at once
+    ):
+        outputs = outputs[skip_echo_len:].strip()
+        now = len(outputs)
+        if now - 1 > pre:
+            if enable_print:
+                print(
+                    Colors.OKBLUE + " ".join(outputs[pre : now - 1]) + Colors.ENDC,
+                    end=" ",
+                    flush=True,
+                )
+            pre = now - 1
+    if enable_print:
+        print(
+            Colors.OKBLUE + " ".join(outputs[pre:]) + Colors.ENDC,
+            flush=True,
+        )
 
-        prompt_len = len(prompt)
-        pre = 0
-        for outputs in model_wrapper.generate(
-            prompt_tokens,
-            prompt_len,
-            temperature=0,  # Use greedy to make it deterministic for benchmarking
-            stop_str=conv.sep if conv.sep_style == SeparatorStyle.SINGLE else conv.sep2,
-            add_bos=add_bos,
-            stream_interval=2048,  # To output at once
-        ):
-            outputs = outputs[prompt_len + 1 :].strip()
-            outputs = outputs.split(" ")
-            now = len(outputs)
-            if now - 1 > pre:
-                print(" ".join(outputs[pre : now - 1]), end=" ", flush=True)
-                pre = now - 1
-        t1 = time.time()
-        print(" ".join(outputs[pre:]), flush=True)
-        print(f"   - # input token: {len(prompt_tokens)}")
-        print(f"   - # output token: {len(outputs)}")
-        print(f"   - process time: {(t1-t0):.3f} s")
+    model_wrapper.sync()
+    t1 = time.time()
+    assert now == len(outputs)
+    elapsed = t1 - t0
+    num_input_prompt_tokens, num_decoded_output_tokens = len(prompt_tokens), len(
+        outputs
+    )
 
-        conv.messages[-1][-1] = " ".join(outputs)
-        add_bos = False
+    return num_input_prompt_tokens, num_decoded_output_tokens, elapsed
+
+
+def benchmark_core_chat(model_wrapper, num_input_tokens, num_output_tokens):
+    model_wrapper.sync()
+    t0 = time.time()
+    model_wrapper.benchmark_core(num_input_tokens, num_output_tokens)
+    model_wrapper.sync()
+    t1 = time.time()
+    return t1 - t0
+
+
+def benchmark(
+    model_wrapper,
+    num_input_tokens,
+    num_output_tokens,
+    num_warm_up,
+    num_measurement,
+    percentiles=[50, 90, 99],
+):
+    # TODO: Until we have kv cache clear in TVM, we just measure once.
+    if model_wrapper.name == "tvm_model_wrapper":
+        num_warm_up = 0
+        num_measurement = 1
+
+    # Warm-up
+    for _ in range(num_warm_up):
+        benchmark_core_chat(model_wrapper, num_input_tokens, num_output_tokens)
+
+    # Actual measurement
+    elapsed = []
+    for _ in range(num_measurement):
+        elapsed.append(
+            benchmark_core_chat(model_wrapper, num_input_tokens, num_output_tokens)
+        )
+    elapsed = [np.percentile(elapsed, p) for p in percentiles]
+    tok_per_sec = [num_output_tokens / e for e in elapsed]
+    return elapsed, tok_per_sec
+
+
+def get_model(mode, tokenizer, ARGS):
+    if mode == "tvm":
+        return TvmModelWrapper(
+            tokenizer,
+            ARGS.max_gen_len,
+            ARGS.conv_template,
+            ARGS.artifact_path,
+            ARGS.model,
+            ARGS.dtype,
+            tvm_device=ARGS.device_name,
+            torch_device="cpu",
+        )
+    elif mode.startswith("torch-"):
+        return TorchModelWrapper(
+            tokenizer,
+            ARGS.max_gen_len,
+            ARGS.conv_template,
+            ARGS.model_path,
+            ARGS.dtype,
+            torch_device="cuda",
+            torch_mode=mode[6:],
+        )
 
 
 if __name__ == "__main__":
     ARGS = _parse_args()
+    # Torch setup
+    torch.set_float32_matmul_precision("high")
+
+    # Tokenizer setup
     tokenizer = get_tokenizer(ARGS.model_path)
     tokenizer.pad_token_id = tokenizer.eos_token_id
-    if not ARGS.run_torch_model:
-        # torch_device = torch.device("cpu")
 
-        model = TvmModelWrapper(
-            tokenizer,
-            ARGS.max_gen_len,
-            ARGS.artifact_path,
-            ARGS.model,
-            ARGS.device_name,
-            ARGS.dtype,
-        )
-    else:
-        model = TorchModelWrapper(
-            tokenizer,
-            ARGS.max_gen_len,
-            ARGS.model_path,
-            ARGS.dtype,
+    prompt = """Repeat the following paragraph exactly: Carlos Alcaraz is a professional tennis player from Spain. He was born on April 12, 1997, and has been playing tennis since he was a child. Alcaraz is known for his aggressive playing style and his ability to come back from difficult situations. He has won several junior tournaments and has also played on the ATP Tour. Alcaraz He has a career high ranking in men’s singles by the Association of Tennis Professionals of world No. 1 achieved on 12 September 2022. He is currently ranked world No. 2 by the ATP. He is known for his strong serve and powerful groundstrokes. He is also known for his positive attitude and his determination to succeed on the court."""
+
+    model_wrapper = get_model(ARGS.benchmark_mode, tokenizer, ARGS)
+
+    # chat(model_wrapper, prompt, True)
+
+    percentiles = [50, 90, 99]
+
+    # TODO: Extend to the list of repr input pairs
+    pairs = [(ARGS.num_input_tokens, ARGS.num_output_tokens)]
+    for num_input_tokens, num_output_tokens in pairs:
+        elapsed, tok_per_sec = benchmark(
+            model_wrapper,
+            num_input_tokens,
+            num_output_tokens,
+            ARGS.num_warm_up,
+            ARGS.num_measurements,
+            percentiles=percentiles,
         )
 
-    inputs = [
-        "Hi",
-        "Repeat this sentence: Sure! Amazon is a multinational technology company that operates in a variety of industries, including e-commerce, cloud computing, digital streaming, and more. The company's headquarters, also known as Amazon Headquarters or Amazon HQ, is located in Seattle, Washington. It is the main base of operations for Amazon.com, Inc., the parent company of Amazon's various subsidiaries and businesses. The headquarters is home to many of the company's executives, as well as its research and development teams, customer service teams, and other support staff.",
-    ]
-    chat(model, inputs)
+        print("|{:^15}|{:^12}|{:^12}|".format("mode", "seqlen", "genlen"), end="")
+        for p in percentiles:
+            print("{:^12}|{:^12}|".format(f"p{p}: sec", f"p{p}: tok/s"), end="")
+        print("")
+        print(
+            "|{:^15}|{:^12}|{:^12}|".format(
+                ARGS.benchmark_mode,
+                num_input_tokens,
+                num_output_tokens,
+            ),
+            end="",
+        )
+        for i in range(len(percentiles)):
+            print("{:^12.3f}|{:^12.3f}|".format(elapsed[i], tok_per_sec[i]), end="")
+        print("")
+    del model_wrapper


### PR DESCRIPTION
Key updates
* Follows Clownfish Benchmarking Proposal: benchmark the core module given (# input tokens, # output tokens) and outputs p50/p90/p99 results
* Add warm-up, measurement interface
* Zero-copy tensor exchange between torch and tvm on GPU - disabled for now until the patch is merged in mlc-ai

Identified issues
* Currently, cannot measure multiple baselines at once due to OOM. To measure multiple baselines at once, need to figure out the way to free GPU memory after finishing the measurement. Tried `torch.cuda.empty_cache()` but didn't work.
* For TVM, we need to clear KV cache for the repeated measurement. Also, need to find a way to free GPU memory after the measurement. 