### PR TITLE
Add option to offload to cuBLAS

### DIFF
--- a/build.py
+++ b/build.py
@@ -7,7 +7,6 @@ from typing import List
 import tvm
 import tvm.testing
 from tvm import relax
-from tvm.relax.backend.pattern_registry import get_pattern
 
 import mlc_llm
 from mlc_llm import utils
@@ -27,6 +26,7 @@ def _parse_args():
     )
     args.add_argument("--no-quantize", action="store_true", default=False)
     args.add_argument("--cutlass-offload", action="store_true", default=False)
+    args.add_argument("--cublas-offload", action="store_true", default=False)
     args.add_argument("--max-seq-len", type=int, default=-1)
     args.add_argument("--target", type=str, default="auto")
     args.add_argument("--db-path", type=str, default="log_db/")
@@ -205,6 +205,38 @@ def debug_dump_shader(ex, name, args):
     print(f"Dump shader to {dump_path}")
 
 
+def cuda_offload(mod, args):
+    import tvm.relax.backend.contrib.cublas
+    import tvm.relax.backend.contrib.cutlass
+    from tvm.relax.backend import get_patterns_with_prefix
+
+    debug_dump_script(mod, "mod_before_cuda_offload.py", args)
+
+    patterns_to_use = []
+
+    if args.cublas_offload:
+        patterns_to_use += get_patterns_with_prefix("cublas")
+    if args.cutlass_offload:
+        patterns_to_use += get_patterns_with_prefix("cutlass")
+
+    partition_pass = relax.transform.FuseOpsByPattern(
+        patterns_to_use,
+        bind_constants=False,
+        annotate_codegen=True,
+    )
+    mod = partition_pass(mod)
+    debug_dump_script(mod, "mod_after_cuda_partition.py", args)
+
+    codegen_pass = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": False}},
+        entry_functions=["encoding", "decoding", "create_kv_cache"],
+    )
+    mod = codegen_pass(mod)
+    debug_dump_script(mod, "mod_after_cuda_codegen.py", args)
+
+    return mod
+
+
 def mod_transform_before_build(
     mod: tvm.IRModule,
     model_params: List[tvm.nd.NDArray],
@@ -221,18 +253,8 @@ def mod_transform_before_build(
             storage_nbit=args.quantization_storage_nbit,
             dtype=args.dtype,
         )(mod)
-    if args.target_kind == "cuda" and args.cutlass_offload:
-        from tvm.relax.backend.contrib.cutlass import partition_for_cutlass
-
-        debug_dump_script(mod, "mod_before_cutlass.py", args)
-        mod = partition_for_cutlass(mod)
-        debug_dump_script(mod, "mod_after_cutlass_partition.py", args)
-        codegen_pass = relax.transform.RunCodegen(
-            {"cutlass": {"sm": 80, "find_first_valid": False}},
-            entry_functions=model_names,
-        )
-        mod = codegen_pass(mod)
-        debug_dump_script(mod, "mod_after_cutlass_codegen.py", args)
+    if args.target_kind == "cuda":
+        mod = cuda_offload(mod, args)
 
     mod = mlc_llm.transform.FuseTransposeMatmul()(mod)
 

--- a/mlc_llm/transform/allow_nonaligned_inputs.py
+++ b/mlc_llm/transform/allow_nonaligned_inputs.py
@@ -3,7 +3,6 @@ from tvm import relax
 from tvm import IRModule
 from tvm.script import tir as T
 
-from debug_utils import ExceptDebug
 
 
 @relax.expr_functor.visitor
@@ -14,7 +13,6 @@ class CallTIRArgCollector(relax.expr_functor.PyExprVisitor):
         self.to_allow_nonaligned = set()
         self._token_params = set()
 
-    @ExceptDebug
     def visit_function_(self, func):
         self._token_params = set(
             param for param in func.params if "input_ids" in param.name_hint
@@ -22,7 +20,6 @@ class CallTIRArgCollector(relax.expr_functor.PyExprVisitor):
         self.visit_expr(func.body)
         self._token_params = set()
 
-    @ExceptDebug
     def visit_var_binding_(self, binding):
         if not isinstance(binding.value, relax.Call):
             return
@@ -89,7 +86,6 @@ def update_primfunc(func: tvm.tir.PrimFunc, arg_i: int) -> tvm.tir.PrimFunc:
 
 @tvm.transform.module_pass(opt_level=0, name="AllowNonAlignedInputs")
 class AllowNonAlignedInputs:
-    @ExceptDebug
     def transform_module(
         self, mod: IRModule, ctx: tvm.transform.PassContext
     ) -> IRModule:


### PR DESCRIPTION
This PR adds option to offload matmul to cuBLAS. It can get about 30% faster than cutlass, even though it doesn't support the matmul with bias (residual) in LLaMA. Mixing the usage of CUTLASS with cuBLAS only makes it slower, so I don't include an option to do that. In this PR if both --cutlass-offload and --cublas-offload are enabled, it will be offloaded to cuBLAS only (the faster option).

Offloads to | 32 tokens P50 tokens/s | 256 tokens P50 tokens/s
-- | -- | --
cuBLAS | 28.279 | 26.572
CUTLASS bias matmul + cuBLAS | 24.498 | 23.528
CUTLASS | 21.289 | 20.866
None | 5.359 | 5.175

Evaluated on A10g

This PR depends on https://github.com/mlc-ai/relax/pull/222 in TVM.

cc @sunggg 

