### PR TITLE
[Cutlass] Attention and combine parallel matmul

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -306,8 +306,23 @@ class LlamaAttention(nn.Module):
             (bsz, tvm.tir.IntImm("int64", 1), q_len, kv_seq_len),
         )
         
-        attn_weights = nn.emit(relax.op.add(attn_weights, attention_mask))
+        attn_weights = nn.emit(
+            maximum(
+                attn_weights,
+                relax.const(
+                    tvm.tir.min_value(attn_weights.struct_info.dtype).value,
+                    attn_weights.struct_info.dtype,
+                ),
+            )
+        )
+        attn_weights = nn.emit(relax.op.minimum(attn_weights, attention_mask))
+
+        # upcast attention to fp32
+        if attn_weights.struct_info.dtype != "float32":
+            attn_weights = astype(attn_weights, "float32")
         attn_weights = nn.emit(softmax(attn_weights, axis=-1))
+        if attn_weights.struct_info.dtype != query_states.struct_info.dtype:
+            attn_weights = astype(attn_weights, query_states.struct_info.dtype)
         attn_output = nn.emit(matmul(attn_weights, value_states))
 
         tvm.ir.assert_structural_equal(
@@ -389,7 +404,7 @@ def _make_causal_mask(input_ids_shape, dtype, src_len):
         return te.compute(
             (tgt_len, tgt_len),
             lambda i, j: tvm.tir.Select(
-                j > i, tvm.tir.min_value(dtype), tvm.tir.FloatImm(dtype, 0)
+                j > i, tvm.tir.min_value(dtype), tvm.tir.max_value(dtype)
             ),
             name="make_diag_mask_te",
         )
@@ -403,7 +418,9 @@ def _make_causal_mask(input_ids_shape, dtype, src_len):
         return te.compute(
             (bsz, 1, tgt_len, src_len),
             lambda b, _, i, j: te.if_then_else(
-                j < src_len - tgt_len, tvm.tir.FloatImm(dtype, 0), x[b, _, i, j - (src_len - tgt_len)]
+                j < src_len - tgt_len,
+                tvm.tir.max_value(dtype),
+                x[b, _, i, j - (src_len - tgt_len)],
             ),
             name="concat_te",
         )
@@ -436,7 +453,13 @@ class LlamaModel(nn.Module):
             # Get src_len from input parameters
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
             bsz, tgt_len = input_shape
-            combined_attention_mask = nn.emit(relax.op.full((bsz, 1, tgt_len, src_len), relax.const(0, dtype), dtype))
+            combined_attention_mask = nn.emit(
+                relax.op.full(
+                    (bsz, 1, tgt_len, src_len),
+                    relax.const(tvm.tir.max_value(dtype).value, dtype),
+                    dtype,
+                )
+            )
         return combined_attention_mask
 
     def forward(

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -7,3 +7,4 @@ from .transpose_matmul import FuseTransposeMatmul
 from .decode_matmul_ewise import FuseDecodeMatmulEwise
 from .allow_nonaligned_inputs import AllowNonAlignedInputs
 from .rewrite_attention import rewrite_attention
+from .combine_parallel_matmul import combine_parallel_transposed_matmul

--- a/mlc_llm/transform/combine_parallel_matmul.py
+++ b/mlc_llm/transform/combine_parallel_matmul.py
@@ -1,0 +1,50 @@
+from tvm.relax.dpl import PatternContext, is_op, rewrite_bindings, wildcard
+from tvm.script import relax as R
+
+
+def combine_parallel_transposed_matmul(f, num_branches):
+    with PatternContext() as ctx:
+        inp_pat = wildcard()
+
+        weight_patterns = []
+        matmul_patterns = []
+
+        for _ in range(num_branches):
+            w_pat = wildcard()
+            weight_patterns.append(w_pat)
+            matmul_patterns.append(
+                is_op("relax.matmul")(inp_pat, is_op("relax.permute_dims")(w_pat))
+            )
+
+    def rewriter(matchings, *_):
+        inp = matchings[inp_pat]
+
+        weights = [matchings[w_pat] for w_pat in weight_patterns]
+        concat = R.concat(weights, axis=0)
+        matmul = R.matmul(inp, R.permute_dims(concat))
+
+        replacements = {}
+
+        sections = []
+        ind = 0
+        for i, matmul_pat in enumerate(matmul_patterns[:-1]):
+            width = weights[i].struct_info.shape[0]
+            ind += width
+            sections.append(int(ind))
+
+        if len(inp.struct_info.shape) == 3:
+            slice_axis = 2
+        elif len(inp.struct_info.shape) == 2:
+            slice_axis = 1
+        else:
+            assert False
+
+        chunks = R.split(matmul, sections, slice_axis)
+
+        for i, matmul_pat in enumerate(matmul_patterns):
+            bound_var = matchings[matmul_pat]
+            replacements[bound_var] = chunks[i]
+
+        return replacements
+
+    return rewrite_bindings(ctx, rewriter, f)

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -6,7 +6,6 @@ def rewrite_attention(f):
     Q = wildcard()
     K = wildcard()
     V = wildcard()
-    bias = wildcard()
 
     Q_BNSH = is_op("relax.permute_dims")(Q)
     K_BNSH = is_op("relax.permute_dims")(K)
@@ -16,13 +15,16 @@ def rewrite_attention(f):
 
     matmul1 = is_op("relax.matmul")(Q_BNSH, K_BNSH_T)
     divide = is_op("relax.divide")(matmul1, is_const())
-    with_bias = is_op("relax.add")(divide, bias)
-    softmax = is_op("relax.nn.softmax")(with_bias)
-    matmul2 = is_op("relax.matmul")(softmax, V_BNSH)
+    max = is_op("relax.maximum")(divide, is_const())
+    min = is_op("relax.minimum")(max, wildcard())
+    softmax = is_op("relax.nn.softmax")(is_op("relax.astype")(min))
+    matmul2 = is_op("relax.matmul")(is_op("relax.astype")(softmax), V_BNSH)
 
     pattern = is_op("relax.permute_dims")(matmul2)
 
     def callback(_, matchings):
-        return R.nn.attention(matchings[Q], matchings[K], matchings[V], matchings[bias])
+        return R.nn.attention(
+            matchings[Q], matchings[K], matchings[V], causal_mask="BottomRight"
+        )
 
     return rewrite_call(pattern, callback, f)

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -162,13 +162,13 @@ class TvmModelWrapper(ModelWrapper):
             if cur_pos == start_pos:
                 # TODO: switch to the below when Eric's PR is merged.
                 # tok = tvm.nd.from_dlpack(tokens[:, :cur_pos])
-                tok = tvm.nd.array(tokens[:, :cur_pos].numpy(), self.tvm_device)
+                tok = tvm.nd.array(tokens[:, :cur_pos].cpu().numpy(), self.tvm_device)
                 logits = self.model(tok)
             else:
                 # TODO: switch to the below when Eric's PR is merged.
                 # tok = tvm.nd.from_dlpack(tokens[:, cur_pos - 1 : cur_pos])
                 tok = tvm.nd.array(
-                    tokens[:, cur_pos - 1 : cur_pos].numpy(), self.tvm_device
+                    tokens[:, cur_pos - 1 : cur_pos].cpu().numpy(), self.tvm_device
                 )
                 logits = self.model(tok)
 
@@ -230,13 +230,13 @@ class TvmModelWrapper(ModelWrapper):
             if cur_pos == start_pos:
                 # TODO: switch to the below when Eric's PR is merged.
                 #    tok = tvm.nd.from_dlpack(tokens[:, :cur_pos])
-                tok = tvm.nd.array(tokens[:, :cur_pos].numpy(), self.tvm_device)
+                tok = tvm.nd.array(tokens[:, :cur_pos].cpu().numpy(), self.tvm_device)
                 logits = self.model(tok)
             else:
                 # TODO: switch to the below when Eric's PR is merged.
                 #    tok = tvm.nd.from_dlpack(tokens[:, cur_pos - 1 : cur_pos])
                 tok = tvm.nd.array(
-                    tokens[:, cur_pos - 1 : cur_pos].numpy(), self.tvm_device
+                    tokens[:, cur_pos - 1 : cur_pos].cpu().numpy(), self.tvm_device
                 )
                 logits = self.model(tok)
 
@@ -575,7 +575,6 @@ def get_model_wrapper(mode, tokenizer, ARGS):
             ARGS.quantization.name,
             ARGS.quantization.model_dtype,
             tvm_device=ARGS.device_name,
-            torch_device="cpu", # TODO: change to "cuda" when dlpack conversion works.
         )
     elif mode.startswith("torch-"):
         return TorchModelWrapper(


### PR DESCRIPTION
This PR adds cutlass attention offloading and combine parallel matmul. It depends a couple of PRs from the unity branch to run. I created https://github.com/mlc-ai/relax/pull/254 to get these into the mlc branch.

Perf numbers:
|     mode      |   seqlen   |   genlen   |  p50: sec  | p50: tok/s |  p90: sec  | p90: tok/s |  p99: sec  | p99: tok/s |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
|      tvm      |     32     |     32     |   0.967    |   33.093   |   0.967    |   33.080   |   0.967    |   33.077   |
|torch-inductor |     32     |     32     |   0.999    |   32.040   |   0.999    |   32.037   |   0.999    |   32.037   |
|      tvm      |    128     |    128     |   3.867    |   33.098   |   3.868    |   33.091   |   3.869    |   33.081   |
|torch-inductor |    128     |    128     |   4.054    |   31.577   |   4.054    |   31.576   |   4.054    |   31.576   |
|      tvm      |    512     |    512     |   15.932   |   32.136   |   15.942   |   32.117   |   15.943   |   32.115   |
|torch-inductor |    512     |    512     |   17.488   |   29.277   |   17.546   |   29.180   |   18.011   |   28.428   |

TVM is **3.3% faster** than TorchInductor with 32 input/output sequence length and **9.8% faster** than TorchInductor with 512 input/output sequence length.

To reproduce this benchmark,
run 
```
python3 tests/benchmark.py --model vicuna-v1-7b --quantization q0f16 --num-warm-up=5  --num-measurements=10 --num-input-tokens=32 --num-output-tokens=32
```
to get numbers for tvm, and run
```
python3 tests/benchmark.py --model vicuna-v1-7b --quantization q0f16 --num-warm-up=5  --num-measurements=10 --num-input-tokens=32 --num-output-tokens=32 --benchmark-mode=torch-inductor
```
to get numbers for inductor.

cc @masahi @sunggg 