### PR TITLE
Port `benchmark_serving.py` and `benchmark_throughput` from vllm

### DIFF
--- a/serve/benchmarks/benchmark_serving.py
+++ b/serve/benchmarks/benchmark_serving.py
@@ -1,0 +1,209 @@
+import argparse
+import asyncio
+import json
+import random
+import time
+from typing import AsyncGenerator, List, Tuple
+
+import aiohttp
+import numpy as np
+from transformers import PreTrainedTokenizerBase
+from vllm.transformers_utils.tokenizer import get_tokenizer
+
+
+# (prompt len, output len, latency)
+REQUEST_LATENCY: List[Tuple[int, float]] = []
+RESPONSES = []
+
+
+def sample_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[Tuple[str, int, int]]:
+    # Load the dataset.
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # Filter out the conversations with less than 2 turns.
+    dataset = [data for data in dataset if len(data["conversations"]) >= 2]
+    # Only keep the first two turns of each conversation.
+    dataset = [
+        (data["conversations"][0]["value"], data["conversations"][1]["value"])
+        for data in dataset
+    ]
+
+    # Tokenize the prompts and completions.
+    prompts = [prompt for prompt, _ in dataset]
+    prompt_token_ids = tokenizer(prompts).input_ids
+    completions = [completion for _, completion in dataset]
+    completion_token_ids = tokenizer(completions).input_ids
+    tokenized_dataset = []
+    for i in range(len(dataset)):
+        output_len = len(completion_token_ids[i])
+        tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+
+    # Filter out too long sequences.
+    filtered_dataset: List[Tuple[str, int, int]] = []
+    for prompt, prompt_token_ids, output_len in tokenized_dataset:
+        prompt_len = len(prompt_token_ids)
+        if prompt_len < 4 or output_len < 4:
+            # Prune too short sequences.
+            # This is because TGI causes errors when the input or output length
+            # is too short.
+            continue
+        if prompt_len > 1024 or prompt_len + output_len > 2048:
+            # Prune too long sequences.
+            continue
+        filtered_dataset.append((prompt, prompt_len, output_len))
+
+    # Sample the requests.
+    sampled_requests = random.sample(filtered_dataset, num_requests)
+    return sampled_requests
+
+
+async def get_request(
+    input_requests: List[Tuple[str, int, int]],
+    request_rate: float,
+) -> AsyncGenerator[Tuple[str, int, int], None]:
+    input_requests = iter(input_requests)
+    for request in input_requests:
+        yield request
+
+        if request_rate == float("inf"):
+            # If the request rate is infinity, then we don't need to wait.
+            continue
+        # Sample the request interval from the exponential distribution.
+        interval = np.random.exponential(1.0 / request_rate)
+        # The next request will be sent after the interval.
+        await asyncio.sleep(interval)
+
+
+async def send_request(
+    api_url: str,
+    prompt: str,
+    prompt_len: int,
+    output_len: int,
+    best_of: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    request_start_time = time.time()
+
+    headers = {"User-Agent": "Benchmark Client"}
+    pload = {
+        "model": "test",
+        "messages": prompt,
+        "max_tokens": output_len,
+        "stream": False,
+        "temperature": 1.0,
+        "top_p": 1,
+        "presence_penalty": 0,
+        "frequency_penalty": 0,
+        "ignore_eos": True,
+    }
+
+    timeout = aiohttp.ClientTimeout(total=3 * 3600)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while True:
+            async with session.post(api_url, headers=headers, json=pload) as response:
+                chunks = []
+                async for chunk, _ in response.content.iter_chunks():
+                    chunks.append(chunk)
+            output = b"".join(chunks).decode("utf-8")
+            output = json.loads(output)
+
+            # Re-send the request if it failed.
+            if "error" not in output:
+                break
+
+    request_end_time = time.time()
+    request_latency = request_end_time - request_start_time
+
+    REQUEST_LATENCY.append((prompt_len, request_latency))
+    RESPONSES.append((prompt, output["choices"][0]["message"]["content"]))
+
+
+async def benchmark(
+    api_url: str,
+    input_requests: List[Tuple[str, int, int]],
+    best_of: int,
+    request_rate: float,
+    tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    tasks: List[asyncio.Task] = []
+    async for request in get_request(input_requests, request_rate):
+        prompt, prompt_len, output_len = request
+        task = asyncio.create_task(
+            send_request(api_url, prompt, prompt_len, output_len, best_of, tokenizer)
+        )
+        tasks.append(task)
+    await asyncio.gather(*tasks)
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
+    api_url = f"http://127.0.0.1:8000/v1/chat/completions"
+    tokenizer = get_tokenizer(args.tokenizer, trust_remote_code=False)
+    input_requests = sample_requests(args.dataset, args.num_prompts, tokenizer)
+
+    benchmark_start_time = time.time()
+    asyncio.run(
+        benchmark(api_url, input_requests, args.best_of, args.request_rate, tokenizer)
+    )
+    benchmark_end_time = time.time()
+    benchmark_time = benchmark_end_time - benchmark_start_time
+
+    print(f"Total time: {benchmark_time:.2f} s")
+    throughput = args.num_prompts / benchmark_time
+    print(f"Throughput: {throughput:.2f} requests/s")
+
+    if args.dump_responses:
+        for prompt, response in RESPONSES:
+            print(f"Prompt: {prompt}")
+            print(f"Response: {response}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark the online serving throughput."
+    )
+    parser.add_argument(
+        "--dataset", type=str, required=True, help="Path to the dataset."
+    )
+    parser.add_argument(
+        "--tokenizer", type=str, required=True, help="Name or path of the tokenizer."
+    )
+    parser.add_argument(
+        "--best-of",
+        type=int,
+        default=1,
+        help="Generates `best_of` sequences per prompt and " "returns the best one.",
+    )
+    parser.add_argument(
+        "--num-prompts", type=int, default=1000, help="Number of prompts to process."
+    )
+    parser.add_argument(
+        "--request-rate",
+        type=float,
+        default=float("inf"),
+        help="Number of requests per second. If this is inf, "
+        "then all the requests are sent at time 0. "
+        "Otherwise, we use Poisson process to synthesize "
+        "the request arrival times.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--report-path",
+        type=str,
+        default=None,
+        help="Append the current result to the given path if provided.",
+    )
+    parser.add_argument(
+        "--dump-responses",
+        action="store_true",
+        help="Dump prompt / response pairs to stdout.",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -1,0 +1,171 @@
+"""Benchmark offline inference throughput."""
+import os
+import argparse
+import json
+import random
+import time
+from typing import List, Tuple
+
+from transformers import PreTrainedTokenizerBase
+
+from mlc_llm import utils
+from mlc_serve.engine import (
+    Request,
+    SamplingParams,
+    StoppingCriteria,
+)
+from mlc_serve.engine.local import LocalProcessInferenceEngine
+from mlc_serve.model.paged_cache_model import init_model
+
+import pandas as pd
+
+
+def sample_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[Tuple[str, int, int]]:
+    # Load the dataset.
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # Filter out the conversations with less than 2 turns.
+    dataset = [data for data in dataset if len(data["conversations"]) >= 2]
+    # Only keep the first two turns of each conversation.
+    dataset = [
+        (data["conversations"][0]["value"], data["conversations"][1]["value"])
+        for data in dataset
+    ]
+
+    # Tokenize the prompts and completions.
+    prompts = [prompt for prompt, _ in dataset]
+    prompt_token_ids = tokenizer(prompts).input_ids
+    completions = [completion for _, completion in dataset]
+    completion_token_ids = tokenizer(completions).input_ids
+    tokenized_dataset = []
+    for i in range(len(dataset)):
+        output_len = len(completion_token_ids[i])
+        tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+
+    # Filter out too long sequences.
+    filtered_dataset: List[Tuple[str, int, int]] = []
+    for prompt, prompt_token_ids, output_len in tokenized_dataset:
+        prompt_len = len(prompt_token_ids)
+        if prompt_len < 4 or output_len < 4:
+            # Prune too short sequences.
+            continue
+        if prompt_len > 1024 or prompt_len + output_len > 2048:
+            # Prune too long sequences.
+            continue
+        filtered_dataset.append((prompt, prompt_len, output_len))
+
+    # Sample the requests.
+    sampled_requests = random.sample(filtered_dataset, num_requests)
+    return sampled_requests
+
+
+def run_mlc(
+    requests: List[Tuple[str, int, int]],
+    engine,
+) -> float:
+    for i, (prompt, _, output_len) in enumerate(requests):
+        sampling_params = SamplingParams(
+            n=1,
+            temperature=1.0,
+            top_p=1.0,
+            ignore_eos=True,
+        )
+
+        engine.add(
+            [
+                Request(
+                    request_id=str(i),
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                    stopping_criteria=StoppingCriteria(max_tokens=output_len),
+                )
+            ]
+        )
+
+    start = time.time()
+
+    while engine._has_request_to_process():
+        engine.step()
+
+    end = time.time()
+    return end - start
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+
+    # Sample the requests.
+    model_executor, tokenizer = init_model(
+        args.model,
+        args.artifact_path,
+        args.quantization.name,
+        args.num_shards,
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        max_input_len=args.max_input_len,
+    )
+
+    engine = LocalProcessInferenceEngine(model_executor, tokenizer)
+
+    requests = sample_requests(args.dataset, args.num_prompts, tokenizer)
+
+    elapsed_time = run_mlc(
+        requests,
+        engine,
+    )
+
+    total_num_tokens = sum(
+        prompt_len + output_len for _, prompt_len, output_len in requests
+    )
+    req_per_sec = len(requests) / elapsed_time
+    tok_per_sec = total_num_tokens / elapsed_time
+
+    print(
+        f"Throughput: {req_per_sec:.2f} requests/s, "
+        f"{total_num_tokens / elapsed_time:.2f} tokens/s"
+    )
+    if args.report_path is not None:
+        data = {
+            "# prompts": [args.num_prompts],
+            "req/s": [req_per_sec],
+            "tok/s": [tok_per_sec],
+            "elapsed time (s)": [elapsed_time],
+        }
+        df = pd.DataFrame(data)
+        df.to_csv(args.report_path, mode="a", index=False, header=False)
+        print("Data appended successfully.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark the throughput.")
+    parser.add_argument(
+        "--dataset", type=str, required=True, help="Path to the dataset."
+    )
+    parser.add_argument("--local-id", type=str, required=True)
+    parser.add_argument("--artifact-path", type=str, default="dist")
+    parser.add_argument("--num-shards", type=int, default=1)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=-1)
+    parser.add_argument("--max-input-len", type=int, default=-1)
+    parser.add_argument(
+        "--num-prompts", type=int, default=1000, help="Number of prompts to process."
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--report-path",
+        type=str,
+        default=None,
+        help="Append the current result to the given path if provided.",
+    )
+    args = parser.parse_args()
+
+    args.model, args.quantization = args.local_id.rsplit("-", 1)
+    utils.argparse_postproc_common(args)
+    args.artifact_path = os.path.join(
+        args.artifact_path, f"{args.model}-{args.quantization.name}-batched"
+    )
+
+    main(args)


### PR DESCRIPTION
Example cmdline with disco:
```
python serve/benchmarks/benchmark_throughput.py --dataset serve/benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json --local-id vicuna-v1-7b-q0f16 --num-shards 2 --max-num-batched-tokens 2560 --max-input-len 256 
```

For `benchmark_serving.py`, need to run
```
python -m mlc_serve  --local-id vicuna-v1-7b-q4f16_1
```
beforehand.