### PR TITLE
Copy the result of `R.max(seq_lens)` to CPU once to remove redundant `cudaMemcpy`

### DIFF
--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -168,8 +168,5 @@ if __name__ == "__main__":
 
     args.model, args.quantization = args.local_id.rsplit("-", 1)
     utils.argparse_postproc_common(args)
-    args.artifact_path = os.path.join(
-        args.artifact_path, f"{args.model}-{args.quantization.name}-batched"
-    )
 
     main(args)


### PR DESCRIPTION
Need a commit https://github.com/masahi/tvm/commit/91c37e7201be75f47e82f8267861c214f1aa9b7f from `contrib-llvm` to work with this change.