### PR TITLE
[Refactor] Calculate `slot_mappings` outside of `generate` 

### DIFF
--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -404,7 +404,6 @@ class Model:
                 sequence_id = request.sequence_id
                 sequence_ids.append(request.sequence_id)
 
-            block_table = cache.block_tables[sequence_id.request_id]
             sampling_params.append(request.sampling_params)
 
             if is_prefill:
@@ -425,6 +424,7 @@ class Model:
                 input_ids.append(request.token_ids[-1])
                 pos = len(request.token_ids) - 1
                 positions.append(pos)
+                block_table = cache.block_tables[sequence_id.request_id]
                 max_num_blocks_per_seq = max(max_num_blocks_per_seq, len(block_table))
                 block_tables.append(block_table)
                 slot_mapping.append(cache.slot_mappings[sequence_id.request_id][-1])

--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -43,6 +43,7 @@ class KVCache:
         )
 
         self.block_tables = defaultdict(list)
+        self.slot_mappings = defaultdict(list)
         self.block_size = block_size
 
 
@@ -90,14 +91,29 @@ class CacheManager:
             if id in self.kv_cache.block_tables and size == 0:
                 self.free_blocks.extend(self.kv_cache.block_tables[id])
                 del self.kv_cache.block_tables[id]
+                del self.kv_cache.slot_mappings[id]
 
-            elif (
-                id in self.kv_cache.block_tables
-                and len(self.kv_cache.block_tables[id]) < num_needed_block
-            ):
-                # Decoding, need to allocate a new block for this request
-                assert len(self.kv_cache.block_tables[id]) + 1 == num_needed_block
-                self.kv_cache.block_tables[id].append(self.free_blocks.pop())
+            elif id in self.kv_cache.block_tables:
+                # Decoding
+
+                if len(self.kv_cache.block_tables[id]) < num_needed_block:
+                    # Need to allocate a new block for this request
+                    assert len(self.kv_cache.block_tables[id]) + 1 == num_needed_block
+                    self.kv_cache.block_tables[id].append(self.free_blocks.pop())
+
+                block_table = self.kv_cache.block_tables[id]
+                pos = size - 1
+
+                if self.block_sliding_window:
+                    block_number = block_table[
+                        (pos // self.block_size) % self.block_sliding_window
+                    ]
+                else:
+                    block_number = block_table[pos // self.block_size]
+
+                block_offset = pos % self.block_size
+                slot = block_number * self.block_size + block_offset
+                self.kv_cache.slot_mappings[id].append(slot)
 
             elif id not in self.kv_cache.block_tables:
                 assert (
@@ -106,6 +122,21 @@ class CacheManager:
 
                 for _ in range(num_needed_block):
                     self.kv_cache.block_tables[id].append(self.free_blocks.pop())
+
+                block_table = self.kv_cache.block_tables[id]
+
+                for i in range(size):
+                    if self.block_sliding_window:
+                        block_number = block_table[
+                            (i // self.block_size) % self.block_sliding_window
+                        ]
+                    else:
+                        block_number = block_table[i // self.block_size]
+
+                    block_offset = i % self.block_size
+                    slot = block_number * self.block_size + block_offset
+                    self.kv_cache.slot_mappings[id].append(slot)
+
 
     def get_cache(self):
         return self.kv_cache
@@ -352,7 +383,6 @@ class Model:
         slot_mapping = []
         positions = []
         max_num_blocks_per_seq = 0
-        block_size = cache.block_size
         sampling_params = []
         sequence_ids = []
         indices_within_window = []
@@ -376,6 +406,7 @@ class Model:
                 prompt_len = len(request.token_ids)
                 seq_lens.append(prompt_len)
                 positions += range(prompt_len)
+                slot_mapping += cache.slot_mappings[sequence_id.request_id]
 
                 if self.sliding_window:
                     indices_within_window += range(
@@ -384,36 +415,18 @@ class Model:
                     )
                     start_idx += prompt_len
 
-                for i in range(len(request.token_ids)):
-                    if self.sliding_window:
-                        block_number = block_table[
-                            (i // block_size) % self.block_sliding_window
-                        ]
-                    else:
-                        block_number = block_table[i // block_size]
-
-                    block_offset = i % block_size
-                    slot = block_number * block_size + block_offset
-                    slot_mapping.append(slot)
             else:
                 input_ids.append(request.token_ids[-1])
                 pos = len(request.token_ids) - 1
                 positions.append(pos)
                 max_num_blocks_per_seq = max(max_num_blocks_per_seq, len(block_table))
                 block_tables.append(block_table)
+                slot_mapping.append(cache.slot_mappings[sequence_id.request_id][-1])
 
                 if self.sliding_window:
                     seq_lens.append(min(len(request.token_ids), self.sliding_window))
-                    block_number = block_table[
-                        (pos // block_size) % self.block_sliding_window
-                    ]
                 else:
-                    block_number = block_table[pos // block_size]
                     seq_lens.append(len(request.token_ids))
-
-                block_offset = pos % block_size
-                slot = block_number * block_size + block_offset
-                slot_mapping.append(slot)
 
         input_ids_np = np.array(input_ids, dtype="int32")
         input_ids = tvm.nd.array(input_ids_np, self.dev)


### PR DESCRIPTION
Since `slot_mapping` for a new request can be determined as soon as the corresponding `block_table` is created, I think it's cleaner to calculate the former in `set_size(...)` as well. It also lets us consolidate the sliding-window related modulo logic into `set_size(...)`.