### PR TITLE
Do not apply conversation template during benchmarking

### DIFF
--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -80,7 +80,7 @@ def run_mlc(
                     messages=[ChatMessage(role="user", content=prompt)],
                     sampling_params=sampling_params,
                     stopping_criteria=StoppingCriteria(max_tokens=output_len),
-                    debug_options=DebugOptions(ignore_eos=True),
+                    debug_options=DebugOptions(ignore_eos=True, prompt=prompt),
                 )
             ]
         )


### PR DESCRIPTION
7B fp16
```
Before: Throughput: 7.26 requests/s, 3473.79 tokens/s
After: Throughput: 8.56 requests/s, 4095.05 tokens/s
vLLM: Throughput: 8.64 requests/s, 4131.61 tokens/s
```

13B fp16
```
Before: Throughput: 3.89 requests/s, 1858.39 tokens/s
After: Throughput: 4.64 requests/s, 2218.75 tokens/s
vLLM: Throughput: 5.20 requests/s, 2488.75 tokens/s
```