### PR TITLE
New engine implementation and performance optimizations

### DIFF
--- a/serve/mlc_serve/engine/__init__.py
+++ b/serve/mlc_serve/engine/__init__.py
@@ -4,6 +4,7 @@ from .base import (
     DebugOptions,
     FinishReason,
     InferenceEngine,
+    ScopedInferenceEngine,
     InferenceStepResult,
     Request,
     RequestId,

--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -121,6 +121,11 @@ class InferenceEngine:
         The output will contain empty delta and finish reason `cancelled`.
         """
 
+    def has_pending_requests(self) -> bool:
+        """
+        Check if there is pending requests in the engine.
+        """
+
     def wait_for_request(self, timeout_seconds=None) -> bool:
         """
         Block until there is request to process.
@@ -138,3 +143,28 @@ class InferenceEngine:
         If the engine has no requests in the queue, `step` will return immediately with
         an empty `InferenceStepResult.outputs`.
         """
+
+
+class ScopedInferenceEngine(InferenceEngine):
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+@dataclass
+class RequestState:
+    """
+    The internal state of request in the InferenceEngine.
+    """
+
+    request_id: RequestId
+    token_ids: list[int]
+    output_text: str
+    prompt_len: int
+    next_start_position: int
+    sampling_params: SamplingParams
+    stopping_criteria: StoppingCriteria
+    debug_options: DebugOptions
+    is_ended: bool = False

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -151,9 +151,9 @@ class ConversationTemplate(Protocol):
         pass
 
 
-class ModelModule(Protocol):
+class TextTokenGeneratorModule(Protocol):
     """
-    A module that provides components for the actual inference process.
+    A module that provides components for the token generation process.
     """
 
     @property
@@ -164,6 +164,12 @@ class ModelModule(Protocol):
     def cache_manager(self) -> KVCacheManager:
         ...
 
+
+class TokenizerModule(Protocol):
+    """
+    A module that provides components for the tokenization process.
+    """
+
     @property
     def tokenizer(self) -> Tokenizer:
         ...
@@ -171,3 +177,8 @@ class ModelModule(Protocol):
     @property
     def conversation_template(self) -> ConversationTemplate:
         ...
+
+
+class ModelModule(TextTokenGeneratorModule, TokenizerModule):
+    pass
+

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -1,0 +1,232 @@
+"""
+An implementation of InferenceEngine that offloads the text generation loop to another worker process.
+"""
+import logging
+import multiprocessing
+import queue
+from threading import Lock
+from typing import Callable
+
+from .base import (
+    InferenceStepResult,
+    Request,
+    RequestId,
+    RequestOutput,
+    RequestState,
+    ScopedInferenceEngine,
+    SequenceOutput,
+)
+from .model_module import ModelModule, TokenizerModule
+from .staging_engine_worker import (
+    AddRequestsCommand,
+    CancelRequestCommand,
+    ShutdownCommand,
+    run_generation_loop_worker,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StagingInferenceEngine(ScopedInferenceEngine):
+    """
+    An implementation of InferenceEngine that offloads the text generation loop to another worker process,
+    Text tokens are generated asynchronously from the invocation of `step`. The generation progress could be one step
+    ahead of the invocation of `step`. Tokenization and detokenization is still processed synchronously
+    when `step` is called.
+    """
+
+    def __init__(
+        self,
+        tokenizer_module: TokenizerModule,
+        model_module_loader: Callable[..., ModelModule],
+        model_module_loader_kwargs: dict,
+        max_batched_tokens: int = 2560,
+        min_decode_steps: int = 32,
+        max_decode_steps: int = 48,
+        prompt_allocate_ratio: float = 2.0,
+    ):
+        self.next_generation_output = None
+        self.requests_lock = Lock()
+        self.requests = dict[RequestId, RequestState]()
+
+        self.tokenizer = tokenizer_module.tokenizer
+        self.conversation_template = tokenizer_module.conversation_template
+
+        self.mp_context = multiprocessing.get_context("spawn")
+        self.command_queue = self.mp_context.Queue()
+        self.result_queue = self.mp_context.Queue(maxsize=1)
+        self.ready_event = self.mp_context.Event()
+        self.worker_process = self.mp_context.Process(
+            target=run_generation_loop_worker,
+            args=(
+                model_module_loader,
+                model_module_loader_kwargs,
+                {
+                    "max_batched_tokens": max_batched_tokens,
+                    "min_decode_steps": min_decode_steps,
+                    "max_decode_steps": max_decode_steps,
+                    "prompt_allocate_ratio": prompt_allocate_ratio,
+                },
+                self.command_queue,
+                self.result_queue,
+                self.ready_event,
+            ),
+        )
+
+    def start(self):
+        self.worker_process.start()
+        if not self.ready_event.wait(timeout=180):
+            raise RuntimeError(
+                "StagingInferenceEngine worker is not ready before timeout."
+            )
+
+    def stop(self):
+        self.command_queue.put(ShutdownCommand())
+        self.worker_process.join()
+
+    def add(self, requests: list[Request]):
+        if not self._is_ready_to_serve():
+            raise RuntimeError("GenerationLoopWorker process is not running")
+
+        new_request_states = []
+        for req in requests:
+            # TODO: verify that request id is unique
+            if req.num_sequences > 1:
+                raise RuntimeError("num_sequences > 1 is not supported for now")
+            state = self._get_new_request_state(req)
+            new_request_states.append(state)
+
+        self.command_queue.put(AddRequestsCommand(request_states=new_request_states))
+
+        with self.requests_lock:
+            self.requests.update({s.request_id: s for s in new_request_states})
+
+    def cancel(self, request_id: RequestId):
+        if not self._is_ready_to_serve():
+            raise RuntimeError("GenerationLoopWorker process is not running")
+        self.command_queue.put(CancelRequestCommand(request_id))
+
+    def has_pending_requests(self) -> bool:
+        with self.requests_lock:
+            return len(self.requests) > 0
+
+    def wait_for_request(self, timeout_seconds=None) -> bool:
+        if not self._is_ready_to_serve():
+            raise RuntimeError("GenerationLoopWorker process is not running")
+
+        if self.next_generation_output is not None:
+            return True
+
+        try:
+            self.next_generation_output = self.result_queue.get(timeout=timeout_seconds)
+            return True
+        except queue.Empty:
+            return False
+
+    def step(self) -> InferenceStepResult:
+        if not self._is_ready_to_serve():
+            raise RuntimeError("GenerationLoopWorker process is not running")
+        if not self.has_pending_requests():
+            return InferenceStepResult([])
+
+        if self.next_generation_output is None:
+            generation_output = self.result_queue.get()
+        else:
+            generation_output = self.next_generation_output
+            self.next_generation_output = None
+
+        if generation_output.error is not None:
+            raise RuntimeError(
+                f"Error when calling GenerationLoopWorker: {generation_output.error}"
+            )
+
+        outputs = list[RequestOutput]()
+        with self.requests_lock:
+            for seq_output in generation_output.sequences:
+                # TODO: support multi-sequence per request
+                request_id = seq_output.id.request_id
+                if request_id not in self.requests:
+                    logger.warn(
+                        "Unknown request %s from GenerationLoopWorkerOutput", request_id
+                    )
+                    continue
+
+                state = self.requests[request_id]
+
+                if seq_output.error is not None:
+                    outputs.append(
+                        RequestOutput(
+                            request_id,
+                            sequences=[],
+                            error=seq_output.error,
+                            num_prompt_tokens=state.prompt_len,
+                        )
+                    )
+                    del self.requests[request_id]
+                    continue
+
+                state.next_start_position = len(state.token_ids)
+                state.token_ids.extend(seq_output.new_tokens)
+
+                delta = self._decode_last_output(state)
+                state.output_text += delta
+
+                outputs.append(
+                    RequestOutput(
+                        request_id,
+                        sequences=[
+                            SequenceOutput(
+                                0,
+                                delta=delta,
+                                num_generated_tokens=(
+                                    len(state.token_ids) - state.prompt_len
+                                ),
+                                finish_reason=seq_output.finish_reason,
+                            ),
+                        ],
+                        num_prompt_tokens=state.prompt_len,
+                    )
+                )
+
+                if seq_output.finish_reason is not None:
+                    del self.requests[request_id]
+
+        return InferenceStepResult(outputs=outputs)
+
+    def _is_ready_to_serve(self) -> bool:
+        return self.worker_process is not None and self.worker_process.is_alive()
+
+    def _get_new_request_state(self, request: Request) -> RequestState:
+        if request.debug_options.prompt is not None:
+            prompt = request.debug_options.prompt
+        else:
+            prompt = self.conversation_template.apply(request.messages)
+
+        prompt_tokens = self.tokenizer.encode(prompt)
+
+        return RequestState(
+            request_id=request.request_id,
+            token_ids=prompt_tokens,
+            prompt_len=len(prompt_tokens),
+            next_start_position=0,
+            sampling_params=request.sampling_params,
+            stopping_criteria=request.stopping_criteria,
+            debug_options=request.debug_options,
+            output_text="",
+        )
+
+    def _decode_last_output(self, state: RequestState) -> str:
+        if len(state.output_text):
+            prefix_idx = max(0, state.next_start_position - 6)
+        else:
+            prefix_idx = state.next_start_position
+
+        if prefix_idx == 0:
+            return self.tokenizer.decode(state.token_ids)
+
+        prefix = self.tokenizer.decode(
+            state.token_ids[prefix_idx : state.next_start_position]
+        )
+        full = self.tokenizer.decode(state.token_ids[prefix_idx:])
+
+        return full[len(prefix) :]

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -1,0 +1,387 @@
+"""
+The worker for StagingInferenceEngine
+"""
+
+import logging
+import multiprocessing
+from collections import deque
+from dataclasses import dataclass
+from threading import Condition, Lock, Thread
+from typing import Callable, Optional, Union
+
+from .base import FinishReason, RequestId, RequestState
+from .model_module import DecodeRequest, ModelModule, PrefillRequest, SequenceId
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ShutdownCommand:
+    pass
+
+
+@dataclass
+class AddRequestsCommand:
+    request_states: list[RequestState]
+
+
+@dataclass
+class CancelRequestCommand:
+    request_id: RequestId
+
+
+GenerationLoopWorkerCommand = Union[
+    ShutdownCommand, AddRequestsCommand, CancelRequestCommand
+]
+
+
+@dataclass
+class SequenceGenerationOutput:
+    id: SequenceId
+    new_tokens: list[int]
+    finish_reason: Optional[FinishReason] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class GenerationLoopWorkerOutput:
+    sequences: list[SequenceGenerationOutput]
+    error: Optional[str] = None
+
+
+class GenerationLoopWorker:
+    def __init__(
+        self,
+        model_module: ModelModule,
+        max_batched_tokens: int = 2560,
+        min_decode_steps: int = 32,
+        max_decode_steps: int = 48,
+        prompt_allocate_ratio: float = 2.0,
+    ):
+        self.text_generator = model_module.text_generator
+        self.cache_manager = model_module.cache_manager
+        self.tokenizer = model_module.tokenizer
+
+        self.max_batched_tokens = max_batched_tokens
+        self.max_decode_steps = min(
+            self.cache_manager.get_kv_cache_size(), max_decode_steps
+        )
+        self.min_decode_steps = min(self.max_decode_steps - 1, min_decode_steps)
+        self.prompt_allocate_ratio = prompt_allocate_ratio
+        assert prompt_allocate_ratio >= 1.0
+
+        self.queue_lock = Lock()
+        self.queue = deque[RequestState]()
+        self.has_new_requests = Condition(lock=self.queue_lock)
+
+        self.cancelled_requests = list[RequestState]()
+
+        self.current_batch = dict[RequestId, RequestState]()
+
+    def add(self, request_states: list[RequestState]):
+        with self.queue_lock:
+            self.queue.extend(request_states)
+            self.has_new_requests.notify_all()
+
+    def cancel(self, request_id: RequestId):
+        with self.queue_lock:
+            queue_index_to_delete = None
+            for i, state in enumerate(self.queue):
+                if state.request_id == request_id:
+                    queue_index_to_delete = i
+                    self.cancelled_requests.append(state)
+                    break
+
+            if queue_index_to_delete is not None:
+                del self.queue[queue_index_to_delete]
+
+            if request_id in self.current_batch:
+                self.cancelled_requests.append(self.current_batch[request_id])
+
+    def wait_for_request(self, timeout_seconds=None) -> bool:
+        with self.queue_lock:
+            self.has_new_requests.wait_for(
+                self.has_pending_requests, timeout=timeout_seconds
+            )
+
+    def has_pending_requests(self) -> bool:
+        return self.queue or self.current_batch
+
+    def step(self) -> GenerationLoopWorkerOutput:
+        logger.debug("Starting new inference step.")
+
+        outputs = list[SequenceGenerationOutput]()
+        result = GenerationLoopWorkerOutput(sequences=outputs)
+
+        # TODO: consolidate into a single function
+        for state in list(self.current_batch.values()):
+            finish_reason = None
+            if state.is_ended:
+                finish_reason = FinishReason.Stop
+            if self._should_stop_by_length(state):
+                finish_reason = FinishReason.Length
+
+            if finish_reason is not None:
+                outputs.append(
+                    SequenceGenerationOutput(
+                        # TODO: support multi-sequence
+                        id=SequenceId(state.request_id, 0),
+                        new_tokens=[],
+                        finish_reason=finish_reason,
+                    )
+                )
+                self._remove_request_from_batch(state.request_id)
+
+        for state in self.cancelled_requests:
+            outputs.append(
+                SequenceGenerationOutput(
+                    # TODO: support multi-sequence
+                    id=SequenceId(state.request_id, 0),
+                    new_tokens=[],
+                    finish_reason=FinishReason.Cancelled,
+                )
+            )
+            if state.request_id in self.current_batch:
+                self._remove_request_from_batch(state.request_id)
+
+        self.cancelled_requests.clear()
+
+        self._adjust_batch()
+
+        if not self.current_batch:
+            return result
+
+        requests = self._get_requests_to_process()
+        results = self.text_generator.generate(requests, self.cache_manager.get_cache())
+        logger.debug("Finished text generation.")
+
+        for res in results:
+            # For now we only support single sequence per request
+            request_id = res.sequence_id.request_id
+            if res.error is not None:
+                self._remove_request_from_batch(request_id)
+                outputs.append(
+                    SequenceGenerationOutput(
+                        # TODO: support multi-sequence
+                        id=res.sequence_id,
+                        new_tokens=[],
+                        error=res.error,
+                    )
+                )
+                continue
+
+            state = self.current_batch[request_id]
+            state.next_start_position = len(state.token_ids)
+            new_tokens = res.generated_tokens
+            for i, token_id in enumerate(new_tokens):
+                if (
+                    token_id == self.tokenizer.eos_token_id
+                    and not state.debug_options.ignore_eos
+                ):
+                    new_tokens = new_tokens[:i]
+                    state.is_ended = True
+                    break
+            state.token_ids.extend(new_tokens)
+            outputs.append(
+                SequenceGenerationOutput(id=res.sequence_id, new_tokens=new_tokens)
+            )
+
+        logger.debug("Finished state update and stopping criteria check.")
+
+        return result
+
+    def _adjust_batch(self):
+        with self.queue_lock:
+            while self.cache_manager.get_max_new_tokens() < 1:
+                request_to_remove = min(
+                    self.current_batch.values(), key=lambda s: len(s.token_ids)
+                )
+                self._remove_request_from_batch(request_to_remove.request_id)
+                self.queue.appendleft(request_to_remove)
+                logger.debug(
+                    "Preempt request to free %s tokens",
+                    len(request_to_remove.token_ids),
+                )
+
+            if self.cache_manager.get_max_new_tokens() <= self.max_decode_steps:
+                logger.debug(
+                    "Skip growing the batch due to max_decode_steps. Decode steps: %s",
+                    self.cache_manager.get_max_new_tokens(),
+                )
+                return
+
+            num_new_batched_tokens = len(self.current_batch)
+            while self.queue:
+                max_new_tokens = self.cache_manager.get_max_new_tokens()
+                if max_new_tokens < self.min_decode_steps:
+                    logger.debug(
+                        "Stop growing the batch due to min_decode_steps. Decode steps: %s",
+                        max_new_tokens,
+                    )
+                    # stop adding request if there isn't enough space to do a certain steps of decoding.
+                    break
+                state = self.queue[0]
+                num_tokens = len(state.token_ids)
+                num_new_batched_tokens += num_tokens
+                if num_new_batched_tokens > self.max_batched_tokens > 0:
+                    logger.debug(
+                        "Stop growing the batch due to max_batched_tokens. Batched tokens: %s",
+                        num_new_batched_tokens,
+                    )
+                    break
+                if (
+                    self.cache_manager.get_free_space()
+                    <= self.prompt_allocate_ratio * num_tokens
+                ):
+                    logger.debug(
+                        "Stop growing the batch due to not enough free space. Free: %s, Num tokens: %s",
+                        self.cache_manager.get_free_space(),
+                        num_tokens,
+                    )
+                    break
+
+                self.queue.popleft()
+                self.cache_manager.allocate(state.request_id, num_tokens)
+                self.current_batch[state.request_id] = state
+
+    def _remove_request_from_batch(self, request_id: RequestId):
+        del self.current_batch[request_id]
+        self.cache_manager.free(SequenceId(request_id, 0))
+
+    def _get_requests_to_process(self):
+        requests = []
+        # TODO: consider having hybrid batch if the underlying attention kernel supports
+        # mixing prefill and decode.
+        is_prompt_batch = any(
+            state.next_start_position == 0 for state in self.current_batch.values()
+        )
+
+        if is_prompt_batch:
+            for state in self.current_batch.values():
+                if state.next_start_position == 0:
+                    requests.append(
+                        PrefillRequest(
+                            request_id=state.request_id,
+                            token_ids=state.token_ids,
+                            num_sequence=1,
+                            sampling_params=state.sampling_params,
+                        )
+                    )
+            logger.debug(
+                "Creating prompt batch with %s requests with %s total tokens.",
+                len(requests),
+                sum(len(r.token_ids) for r in requests),
+            )
+        else:
+            for state in self.current_batch.values():
+                seq_id = SequenceId(state.request_id, 0)
+                requests.append(
+                    DecodeRequest(
+                        sequence_id=seq_id,
+                        token_ids=state.token_ids,
+                        sampling_params=state.sampling_params,
+                    )
+                )
+                self.cache_manager.extend(
+                    seq_id, len(state.token_ids) - state.next_start_position
+                )
+            logger.debug("Creating decode batch with %s requests.", len(requests))
+
+        return requests
+
+    def _has_request_to_process(self) -> bool:
+        return self.queue or self.current_batch
+
+    def _should_stop_by_length(self, state: RequestState) -> bool:
+        # TODO: put to config
+        max_tokens = 4096
+        if state.stopping_criteria.max_tokens is not None:
+            max_tokens = min(max_tokens, state.stopping_criteria.max_tokens)
+
+        return len(state.token_ids) - state.prompt_len >= max_tokens
+
+
+def setup_logging(level):
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s [%(levelname)s] - %(name)s - %(message)s",
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": level,  # Set the handler's log level to DEBUG
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": level,  # Set the logger's log level to DEBUG
+        },
+        "mlc_serve.engine.staging_engine_worker": {"level": level},
+    }
+    logging.config.dictConfig(logging_config)
+
+
+def run_generation_loop_worker(
+    model_module_loader: Callable[..., ModelModule],
+    model_module_loader_kwargs: dict,
+    worker_kwargs: dict,
+    command_queue: multiprocessing.Queue,
+    result_queue: multiprocessing.Queue,
+    ready_event: multiprocessing.Event,
+    log_level="INFO",
+):
+    setup_logging(log_level)
+    model_module = model_module_loader(**model_module_loader_kwargs)
+    worker = GenerationLoopWorker(model_module=model_module, **worker_kwargs)
+
+    should_stop = False
+
+    def handle_command():
+        while True:
+            cmd = command_queue.get()
+            if isinstance(cmd, ShutdownCommand):
+                break
+            elif isinstance(cmd, AddRequestsCommand):
+                worker.add(cmd.request_states)
+            elif isinstance(cmd, CancelRequestCommand):
+                worker.cancel(cmd.request_id)
+            else:
+                logger.error("Unknown command type %s", type(cmd))
+                break
+
+        nonlocal should_stop
+        should_stop = True
+
+    handler_thread = Thread(
+        target=handle_command, name="staging-engine-worker-command-handler"
+    )
+    handler_thread.start()
+
+    ready_event.set()
+
+    while True:
+        worker.wait_for_request(timeout_seconds=1)
+        if should_stop:
+            return
+        if not worker.has_pending_requests():
+            continue
+
+        try:
+            output = worker.step()
+        except Exception as exc:
+            logger.exception("Error when calling GenerationLoopWorker.step")
+            output = GenerationLoopWorkerOutput(sequences=[], error=str(exc))
+            result_queue.put(output)
+            break
+
+        if output.sequences:
+            # result_queue should have size limit and the blocking behavior
+            # of queue.put will naturally limits the tokens it generates ahead of time.
+            result_queue.put(output)
+
+    handler_thread.join()

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -9,8 +9,9 @@ from mlc_llm import utils
 
 from .api import create_app
 from .engine import AsyncEngineConnector
-from .engine.local import LocalProcessInferenceEngine
-from .model.paged_cache_model import PagedCacheModelModule
+from .engine.staging_engine import StagingInferenceEngine
+from .engine.sync_engine import SynchronousInferenceEngine
+from .model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
 
 
 def parse_args():
@@ -32,9 +33,11 @@ def parse_args():
     args.add_argument("--local-id", type=str, required=True)
     args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument("--num-shards", type=int, default=1)
+    args.add_argument("--use-staging-engine", action="store_true")
     args.add_argument("--max-num-batched-tokens", type=int, default=-1)
     args.add_argument("--max-input-len", type=int, default=-1)
-    args.add_argument("--min-decode-steps", type=int, default=256)
+    args.add_argument("--min-decode-steps", type=int, default=12)
+    args.add_argument("--max-decode-steps", type=int, default=16)
     args.add_argument("--debug-logging", action="store_true")
     parsed = args.parse_args()
     parsed.model, parsed.quantization = parsed.local_id.rsplit("-", 1)
@@ -66,28 +69,56 @@ def setup_logging(args):
             "handlers": ["console"],
             "level": level,  # Set the logger's log level to DEBUG
         },
-        "mlc_serve.engine.local": {"level": level},
+        "mlc_serve.engine.sync_engine": {"level": level},
+        "mlc_serve.engine.staging_engine": {"level": level},
+        "mlc_serve.engine.staging_engine_worker": {"level": level},
     }
     logging.config.dictConfig(logging_config)
+
+
+def create_engine(
+    args: argparse.Namespace,
+):
+    if args.use_staging_engine:
+        tokenizer_module = HfTokenizerModule(args.model, args.artifact_path)
+        return StagingInferenceEngine(
+            tokenizer_module=tokenizer_module,
+            model_module_loader=PagedCacheModelModule,
+            model_module_loader_kwargs={
+                "model_name": args.model,
+                "artifact_path": args.artifact_path,
+                "quantization": args.quantization.name,
+                "num_shards": args.num_shards,
+                "max_num_batched_tokens": args.max_num_batched_tokens,
+                "max_input_len": args.max_input_len,
+            },
+            max_batched_tokens=args.max_num_batched_tokens,
+            min_decode_steps=args.min_decode_steps,
+            max_decode_steps=args.max_decode_steps,
+        )
+    else:
+        model_module = PagedCacheModelModule(
+            args.model,
+            args.artifact_path,
+            args.quantization.name,
+            args.num_shards,
+            max_num_batched_tokens=args.max_num_batched_tokens,
+            max_input_len=args.max_input_len,
+        )
+
+        return SynchronousInferenceEngine(
+            model_module,
+            max_batched_tokens=args.max_num_batched_tokens,
+            min_decode_steps=args.min_decode_steps,
+            max_decode_steps=args.max_decode_steps,
+        )
 
 
 def run_server():
     args = parse_args()
     setup_logging(args)
-    model_module = PagedCacheModelModule(
-        args.model,
-        args.artifact_path,
-        args.quantization.name,
-        args.num_shards,
-        max_num_batched_tokens=args.max_num_batched_tokens,
-        max_input_len=args.max_input_len,
-    )
 
-    engine = LocalProcessInferenceEngine(
-        model_module,
-        max_batched_tokens=args.max_num_batched_tokens,
-        min_decode_steps=args.min_decode_steps,
-    )
+    engine = create_engine(args)
     connector = AsyncEngineConnector(engine)
     app = create_app(connector)
     uvicorn.run(

--- a/serve/tests/test_engine_paged_cache_model.py
+++ b/serve/tests/test_engine_paged_cache_model.py
@@ -10,7 +10,7 @@ from mlc_serve.engine import (
     SamplingParams,
     StoppingCriteria,
 )
-from mlc_serve.engine.local import LocalProcessInferenceEngine
+from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
 from mlc_serve.model.paged_cache_model import PagedCacheModelModule
 
 
@@ -35,7 +35,7 @@ def test(args: argparse.Namespace):
         max_input_len=args.max_input_len,
     )
 
-    engine = LocalProcessInferenceEngine(
+    engine = SynchronousInferenceEngine(
         model_module,
         max_batched_tokens=args.max_num_batched_tokens,
     )

--- a/serve/tests/test_synchronous_inference_engine.py
+++ b/serve/tests/test_synchronous_inference_engine.py
@@ -10,7 +10,6 @@ from mlc_serve.engine import (
     SamplingParams,
     StoppingCriteria,
 )
-from mlc_serve.engine.local import LocalProcessInferenceEngine
 from mlc_serve.engine.model_module import (
     ConversationTemplate,
     DecodeRequest,
@@ -23,6 +22,7 @@ from mlc_serve.engine.model_module import (
     TextGenerator,
     Tokenizer,
 )
+from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
 
 
 class DummyTokenizer:
@@ -136,7 +136,9 @@ def get_output_for_request(
 
 
 def test_single_request():
-    engine = LocalProcessInferenceEngine(DummaryModelModule(30))
+    engine = SynchronousInferenceEngine(
+        DummaryModelModule(30), max_decode_steps=0, min_decode_steps=0
+    )
     request_id = "1"
     engine.add(
         [
@@ -157,7 +159,9 @@ def test_single_request():
 
 
 def test_single_request_step_to_finish():
-    engine = LocalProcessInferenceEngine(DummaryModelModule(30))
+    engine = SynchronousInferenceEngine(
+        DummaryModelModule(30), max_decode_steps=0, min_decode_steps=0
+    )
 
     request_id = "1"
     engine.add(
@@ -179,7 +183,12 @@ def test_single_request_step_to_finish():
 
 
 def test_multiple_requests_wait_queue():
-    engine = LocalProcessInferenceEngine(DummaryModelModule(20), prompt_allocate_ratio=1.0)
+    engine = SynchronousInferenceEngine(
+        DummaryModelModule(20),
+        max_decode_steps=0,
+        min_decode_steps=0,
+        prompt_allocate_ratio=1.0,
+    )
 
     request_id_1 = "1"
     request_id_2 = "2"
@@ -225,8 +234,11 @@ def test_multiple_requests_wait_queue():
 
 
 def test_multiple_requests_preempt():
-    engine = LocalProcessInferenceEngine(
-        DummaryModelModule(30), min_decode_steps=1, prompt_allocate_ratio=1.0
+    engine = SynchronousInferenceEngine(
+        DummaryModelModule(30),
+        max_decode_steps=0,
+        min_decode_steps=0,
+        prompt_allocate_ratio=1.0,
     )
 
     request_id_1 = "1"


### PR DESCRIPTION
* New StagingInferenceEngine
  * It executes the token id generation loop in a separate process to make the loop tight. 
  * Tokenization and detokenization is done in the main process.
  * Basically this pipelines the prefill/decode and tokenization/detokenization. This is especially beneficial for large batch on small model (or big model with multiple GPUs).
* Separate Prefill and Decode
* Lower the default min_decode_steps
* Add a new param `max_decode_steps`

`StagingInferenceEngine` **brings 20% to 30% throughput improvement** on LLaMA 7B fp16 with single A100 80GB, compared to the old `SynchronousInferenceEngine`.

Using `python serve/benchmarks/benchmark_throughput.py --local-id llama-2-7b-chat-hf-q0f16 --dataset ~/ShareGPT_V3_unfiltered_cleaned_split.json  --max-num-batched-tokens 2560 --max-input-len 512 --num-prompts=1000`,
```
SynchronousInferenceEngine:
Throughput: 8.84 requests/s, 4225.16 tokens/s

StagingInferenceEngine:
Throughput: 10.62 requests/s, 5080.96 tokens/s
```

Under the context of serving API, server is started with 
```
python -m mlc_serve --local-id llama-2-7b-chat-hf-q0f16 --port=8081 --max-num-batched-tokens 2560 --max-input-len=256 --use-staging-engine
```
benchmarked with 200 concurrent requests
```
python3 -m tidallm.run --executor "shared-iterations" --vus 200 --iterations 800 --randomize-max-prompt-length 200 --randomize-max-output-len 200 --model llama-2-7b-chat --endpoint "http://0.0.0.0:8081/v1/chat/completions"
```
Result: 
```
SynchronousInferenceEngine:
Time to first token: 5.05, Toks/sec: 16.82
Latency per token: 59.4511540111433 ms
Throughput: 5866.486260186936 tokens / sec

StagingInferenceEngine:
Time to first token: 3.70, Toks/sec: 22.34
Latency per token: 44.754588647499375 ms
Throughput: 7809.889487796473 tokens / sec
```

The performance improvement would be less significant on larger models.

Caveats:
1. Duplicate code between `StagingInferenceEngine` and `SynchronousEngine`. We can either extract them, if we decide to keep two engine implementations, or delete `SynchronousEngine`, if we decide that `StagingInferenceEngine` is superior in all aspects.
2. The error handling in the engine isn't quite good yet. I've seen `probability tensor contains torch fill nanaeither inf, nan or element < 0` quite often during benchmark under certain kinds of engine parameters. Currently the engine just throws the exception and everything stops. It would be better if it creates error response for all requests in the batch, and continue processing remaining requests.

cc @masahi 