### PR TITLE
[Disco] Switch to build-time sharding and enable FT quantization 

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -707,8 +707,9 @@ def build_model_from_args(args: argparse.Namespace):
                 "`num_shards` should be used together with "
                 "`--build-model-only` and `--convert-weight-only`"
             )
-        if use_ft_quant and not args.use_presharded_weights:
-            raise ValueError("Multi-GPU deployments with FT quantization requires --use-presharded-weights.")
+
+        if use_ft_quant:
+            args.use_presharded_weights = True
 
     os.makedirs(args.artifact_path, exist_ok=True)
     if args.debug_dump:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -705,8 +705,9 @@ def build_model_from_args(args: argparse.Namespace):
                 "`--build-model-only` and `--convert-weight-only`"
             )
         use_ft_quant = args.quantization.name in ["q4f16_ft", "q8f16_ft"]
-        if use_ft_quant:
-            raise ValueError("Multi-GPU deployments are not available for ft quantization.")
+        if use_ft_quant and not args.use_presharded_weights:
+            raise ValueError("Multi-GPU deployments with FT quantization requires --use-presharded-weights.")
+
     os.makedirs(args.artifact_path, exist_ok=True)
     if args.debug_dump:
         os.makedirs(os.path.join(args.artifact_path, "debug"), exist_ok=True)

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -30,6 +30,8 @@ class FTRowwiseQuantizationSpec(QuantizationSpec):
         else:
             self.sm = None
 
+        self.do_preprocess = True
+
     def get_quantize_func(self, param_info: relax.TensorStructInfo) -> Optional[FQuantize]:
         assert self.sm is not None
 
@@ -44,16 +46,20 @@ class FTRowwiseQuantizationSpec(QuantizationSpec):
                 primfunc_name_hint="encode",
             )
             packed_weight = bb.normalize(encoded_data[0])
-            # encoded_weight = bb.emit(
-            #     relax.call_pure_packed(
-            #         "cutlass.ft_preprocess_weight",
-            #         packed_weight,
-            #         self.sm,
-            #         self.nbit == 4,
-            #         sinfo_args=packed_weight.struct_info,
-            #     )
-            # )
-            encoded_weight = packed_weight
+
+            if self.do_preprocess:
+                encoded_weight = bb.emit(
+                    relax.call_pure_packed(
+                        "cutlass.ft_preprocess_weight",
+                        packed_weight,
+                        self.sm,
+                        self.nbit == 4,
+                        sinfo_args=packed_weight.struct_info,
+                    )
+                )
+            else:
+                encoded_weight = packed_weight
+
             return bb.emit(relax.Tuple([encoded_weight, encoded_data[1]]))
 
         return f_quantize

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -44,15 +44,16 @@ class FTRowwiseQuantizationSpec(QuantizationSpec):
                 primfunc_name_hint="encode",
             )
             packed_weight = bb.normalize(encoded_data[0])
-            encoded_weight = bb.emit(
-                relax.call_pure_packed(
-                    "cutlass.ft_preprocess_weight",
-                    packed_weight,
-                    self.sm,
-                    self.nbit == 4,
-                    sinfo_args=packed_weight.struct_info,
-                )
-            )
+            # encoded_weight = bb.emit(
+            #     relax.call_pure_packed(
+            #         "cutlass.ft_preprocess_weight",
+            #         packed_weight,
+            #         self.sm,
+            #         self.nbit == 4,
+            #         sinfo_args=packed_weight.struct_info,
+            #     )
+            # )
+            encoded_weight = packed_weight
             return bb.emit(relax.Tuple([encoded_weight, encoded_data[1]]))
 
         return f_quantize

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -119,7 +119,14 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
 
     if args.quantization not in quantization_schemes:
         raise ValueError(f'Quantization "{args.quantization}" is not supported.')
+
+    use_ft_quant = args.quantization in ["q4f16_ft", "q8f16_ft"]
     args.quantization = quantization_schemes[args.quantization]
+
+    if use_ft_quant and args.num_shards > 1:
+        # Preprocess is done after sharding for this case.
+        args.quantization.linear_weight.do_preprocess = False
+        args.quantization.final_fc_weight.do_preprocess = False
 
 
 def debug_dump_script(mod, name, args: argparse.Namespace, show_meta=True):


### PR DESCRIPTION
Building on @Lunderberg's work in https://github.com/mlc-ai/mlc-llm/pull/1096, we are now switching to build-time sharding in `mlc_serve`. Runtime sharding is no longer supported, and when building a model you must add `--use-presharded-weights`. You also need the latest `contrib-vllm`.

Build-time sharding also lets us support FT quantization with Disco. Now weight preprocessing is applied after sharding.  It has been confirmed to work on 7B and 13B, with both `q4f16_ft` and `q8f16_ft`, with `--num-shards=2`. Other configs will be tested later. 

