### PR TITLE
Switch to ProcessSession for Disco

### DIFF
--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -303,7 +303,7 @@ def sample(logits, sampling_params, vocab_size):
 
 
 def load_disco_module(artifact_path, lib_path, num_shards):
-    sess = di.ThreadedSession(num_workers=num_shards)
+    sess = di.ProcessSession(num_workers=num_shards)
     devices = range(num_shards)
     sess.init_ccl("nccl", *devices)
     module = sess.load_vm_module(lib_path)


### PR DESCRIPTION
On an environment with NVLink, using `ProcessSession` seems to fix the odd hang issues. 

But on an environment without NVLink, after we switched to build-time sharding, `serve/tests/test_engine_paged_cache_model.py` with `ProcessSession` fails with mysterious error:
```
  File "/home/masahi/projects/dev/tvm/src/runtime/disco/nccl/nccl.cc", line 195              
ncclErrror: internal error - please report this issue to the NCCL developers
```
This doesn't happen if the model is initialized from the serving layer. So running this test with disco is broken on such environment, but usual deployment works fine.  