### PR TITLE
[Fix] Compatibility With `pydantic` >= 1.8.0

### DIFF
--- a/serve/mlc_serve/api/handler.py
+++ b/serve/mlc_serve/api/handler.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+import json
 from http import HTTPStatus
 from typing import Annotated, AsyncIterator
 
@@ -146,7 +147,7 @@ async def generate_completion_stream(
             for i in range(num_sequences)
         ],
     )
-    yield f"data: {first_chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+    yield f"data: {json.dumps(first_chunk.dict(exclude_unset=True), ensure_ascii=False)}\n\n"
 
     async for res in result_generator:
         if res.error:
@@ -167,7 +168,7 @@ async def generate_completion_stream(
                 for seq in res.sequences
             ]
         )
-        yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+        yield f"data: {json.dumps(chunk.dict(exclude_unset=True), ensure_ascii=False)}\n\n"
 
     yield "data: [DONE]\n\n"
 

--- a/serve/pyproject.toml
+++ b/serve/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.9"
 description = "LLM Batch Inference server"
 dynamic = ["version"]
 
-dependencies = ["fastapi==0.103.1"]
+dependencies = ["fastapi==0.103.1", "pydantic>=1.8.0"]
 
 [project.optional-dependencies]
 test = ["pytest~=7.4.2", "httpx_sse~=0.3.1", "pytest-timeout~=2.2.0"]


### PR DESCRIPTION
Previously streaming the llm-server will trigger the following error:
```bash
  File "/home/admin/mlc-llm/serve/mlc_serve/api/handler.py", line 170, in generate_completion_stream
    yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/someconda3/lib/python3.11/site-packages/typing_extensions.py", line 2360, in wrapper
    return arg(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/someconda3/lib/python3.11/site-packages/pydantic/main.py", line 994, in json
    raise TypeError('`dumps_kwargs` keyword arguments are no longer supported.')
```

This is because `pydantic` doesn't support this usage after 1.8.0 version, latest is 2.4.2.

This PR fixes it by adding `json` to do the argument transformation.

CC @sunggg 