### PR TITLE
Add handling of max_gen_len from mlc-llm chat_config

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -602,6 +602,11 @@ def dump_mlc_chat_config(
     max_gen_len: int = 512,
     shift_fill_factor: float = 0.3,
     rwkv_world=False,
+    sliding_window = None,
+    hidden_size = 4096,
+    num_attention_heads = 32,
+    num_hidden_layers = 32,
+    num_key_value_heads = None
 ):
     args.params_path = os.path.join(args.artifact_path, "params")
     config: Dict[str, Any] = {}
@@ -636,6 +641,13 @@ def dump_mlc_chat_config(
         config["sliding_window_chunk_size"] = args.sliding_window_chunk_size
     else:
         config["max_window_size"] = max_window_size
+    if sliding_window:
+        config["sliding_window"] = sliding_window
+    config["hidden_size"] = hidden_size
+    config["num_attention_heads"] = num_attention_heads
+    config["num_hidden_layers"] = num_hidden_layers
+    if num_key_value_heads:
+        config["num_key_value_heads"] = num_key_value_heads
 
     args.chat_config_path = os.path.join(args.params_path, "mlc-chat-config.json")
     with open(args.chat_config_path, "w", encoding="utf-8") as outfile:
@@ -836,12 +848,22 @@ def build_model_from_args(args: argparse.Namespace):
                     temperature=1.2,
                     repetition_penalty=0.996,
                     rwkv_world=True,
+                    sliding_window = model_config.sliding_window,
+                    hidden_size = model_config.hidden_size,
+                    num_attention_heads = model_config.num_attention_heads,
+                    num_hidden_layers = model_config.num_hidden_layers,
+                    num_key_value_heads = model_config.num_key_value_heads
                 )
             else:
                 dump_mlc_chat_config(
                     args,
                     vocab_size=config["vocab_size"],
                     max_window_size=model_config.max_sequence_length,
+                    sliding_window = model_config.sliding_window,
+                    hidden_size = model_config.hidden_size,
+                    num_attention_heads = model_config.num_attention_heads,
+                    num_hidden_layers = model_config.num_hidden_layers,
+                    num_key_value_heads = model_config.num_key_value_heads
                 )
 
         if args.convert_weight_only:

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -293,8 +293,7 @@ class GenerationLoopWorker:
         return self.queue or self.current_batch
 
     def _should_stop_by_length(self, state: RequestState) -> bool:
-        # TODO: put to config
-        max_tokens = 4096
+        max_tokens = self.text_generator.model.chat_config.max_gen_len
         if state.stopping_criteria.max_tokens is not None:
             max_tokens = min(max_tokens, state.stopping_criteria.max_tokens)
 

--- a/serve/mlc_serve/engine/sync_engine.py
+++ b/serve/mlc_serve/engine/sync_engine.py
@@ -352,9 +352,8 @@ class SynchronousInferenceEngine(InferenceEngine):
         return full[len(prefix) :]
 
     def _should_stop_by_length(self, state: RequestState) -> bool:
-        # TODO: put to config
-        max_tokens = 4096
+        max_tokens = self.text_generator.model.chat_config.max_gen_len
         if state.stopping_criteria.max_tokens is not None:
             max_tokens = min(max_tokens, state.stopping_criteria.max_tokens)
 
-        return len(state.token_ids) - state.prompt_len >= max_tokens
+        return len(state.token_ids) - state.prompt_len > max_tokens


### PR DESCRIPTION
Plugged chat_config created during build of the model and started to use existed required parameters from this config instead of HF one

Get rid of the hardcoded context length, started to use max_gen_len parameter from chat_config

NOTE - this fix requires to rebase on mlc-llm [PR1249](https://github.com/mlc-ai/mlc-llm/pull/1249) to end-to-end scenario work properly