### PR TITLE
[WIP] Support logprob calculation for loglikelihood approach

### DIFF
--- a/serve/mlc_serve/api/handler.py
+++ b/serve/mlc_serve/api/handler.py
@@ -71,8 +71,11 @@ def _get_sampling_params(
     if request.logprobs:
         sampling_params.top_logprobs = request.top_logprobs
         sampling_params.logprobs = request.logprobs
+    if request.loglikelihood:
+        sampling_params.loglikelihood = request.loglikelihood
 
     sampling_params.vocab_size = model_artifact_config.vocab_size
+
     return sampling_params
 
 
@@ -121,6 +124,11 @@ async def request_completion(
             issues with sampling parameters
             """
         )
+
+    # If loglikelihood True we need all logprobs from prefill step only
+    if request.loglikelihood:
+        request.max_tokens = 0
+
     # TODO(amalyshe): need to verify quantity, according to OpenAI API:
     # <<Up to 4 sequences where the API will stop generating further tokens.>>
     # The behavior in case of bigger number of stop sequences is unknown - need to shrink

--- a/serve/mlc_serve/api/protocol.py
+++ b/serve/mlc_serve/api/protocol.py
@@ -75,6 +75,7 @@ class ChatCompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     logprobs: bool = False
     top_logprobs: int = 0
+    loglikelihood: bool = False
 
 
 class ChatCompletionResponseChoice(BaseModel):

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -33,6 +33,13 @@ class PrefillRequest:
 
 
 @dataclass
+class LoglikelihoodRequest:
+    request_id: RequestId
+    token_ids: List[int]
+    sampling_params: SamplingParams
+
+
+@dataclass
 class DecodeRequest:
     sequence_id: SequenceId
     prompt_token_counts: int
@@ -67,7 +74,7 @@ class EvalMultiQueryRequest:
     sampling_params: SamplingParams
 
 
-RequestType = Union[PrefillRequest, DecodeRequest, EvalMultiQueryRequest]
+RequestType = Union[PrefillRequest, LoglikelihoodRequest, DecodeRequest, EvalMultiQueryRequest]
 
 
 @dataclass

--- a/serve/mlc_serve/engine/sampling_params.py
+++ b/serve/mlc_serve/engine/sampling_params.py
@@ -69,6 +69,7 @@ class SamplingParams:
     logit_bias_value: list[float] = None
     logprobs: bool = False
     top_logprobs: int = 0
+    loglikelihood: bool = False
     # TODO(@team): This info comes from the model config.
     # Currently, it is unclear what is the best way to fetch this info and
     # check in `_verify_args` without this field. Follow-up when we have a better idea.

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -333,6 +333,7 @@ class GenerationLoopWorker(EngineBase):
         )
 
         if is_prompt_batch:
+            # TODO(vvchernov): There are loglikelihood requests, do we need to separate them?
             self.prom_metrics.histogram(BATCHED_PREFILL_TOKENS).observe(token_counts)
         else:
             self.prom_metrics.histogram(BATCHED_DECODE_TOKENS).observe(token_counts)

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -81,7 +81,7 @@ def sample_from_logits(
     logits: Union[tvm.nd.NDArray, torch.Tensor],
     sequence_ids: List[SequenceId],
     requests: Sequence[RequestType],
-    sampling_metadata: SamplingState,
+    sampling_state: SamplingState,
     vocab_size: int,
     copy_stream: torch.cuda.Stream,
     torch_dtype: torch.dtype,
@@ -97,13 +97,13 @@ def sample_from_logits(
     # synchronization point for sampling tensors
     # wait until all the tensors are loaded on GPU
     torch.cuda.current_stream().wait_stream(copy_stream)
-    logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    logits = adjust_logits(logits, sampling_state, vocab_size)
     outputs: List[TextGenerationResult] = []
 
     try:
         sampling_output: Optional[SamplingOutput] = sample(
             logits,
-            sampling_metadata,
+            sampling_state,
         )
 
         for i, (new_token, logprob_info) in enumerate(
@@ -129,13 +129,13 @@ def sample_from_logits(
         for i in range(batch_size):
             sequence_id = sequence_ids[i]
             logits_per_token = logits[i]
-            sampling_param = sampling_metadata.sampling_params[i]
+            sampling_param = sampling_state.sampling_params[i]
             past_decode_tokens_per_request = past_decode_tokens[i]
             # NOTE: Rerun the preparation for simplicity.
             # Assume this code path is taken rarely and the recomputation overhead is
             # marginal.
             with torch.cuda.stream(copy_stream):
-                new_sampling_metadata = SamplingState.from_sampling_params(
+                new_sampling_state = SamplingState.from_sampling_params(
                     [sampling_param],
                     [past_decode_tokens_per_request],
                     torch_dtype,
@@ -145,7 +145,7 @@ def sample_from_logits(
             torch.cuda.current_stream().wait_stream(copy_stream)
             maybe_sampling_output: Optional[SamplingOutput] = sample(
                 torch.unsqueeze(logits_per_token, 0),
-                new_sampling_metadata,
+                new_sampling_state,
                 check_safety=True,
             )
 

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -190,7 +190,7 @@ def sample_loglikelihood_from_logits(
                     sequence_id=sequence_id,
                     generated_tokens=[],
                     error=None,
-                    logprob_info=logprob_infos[i],
+                    logprob_info=get_logprob_infos(i, logprob_infos),
                 )
             )
 

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -176,10 +176,23 @@ def sample_from_logits(
     return outputs
 
 
+def get_logprob_infos(
+        i: int,
+        logprob_infos: Optional[List[Optional[RawLogprobsInfo]]],
+    ) -> Optional[List[Optional[RawLogprobsInfo]]]:
+        if logprob_infos is None or logprob_infos[i] is None:
+            return None
+        return [logprob_infos[i]]
+
+
 def sample_loglikelihood_from_logits(
     logits: Union[tvm.nd.NDArray, torch.Tensor],
     sequence_ids: List[SequenceId],
 ) -> List[TextGenerationResult]:
+    # Convert to torch tensors if logits are in tvm ndarray
+    if isinstance(logits, tvm.nd.NDArray):
+        logits = torch.from_dlpack(logits)
+
     # TODO(vvchernov): cut prompt lengths from logits
     try:
         logprob_infos = loglikelihood_sample(logits)

--- a/serve/mlc_serve/model/paged_cache_manager.py
+++ b/serve/mlc_serve/model/paged_cache_manager.py
@@ -1,6 +1,6 @@
 import math
 from collections import defaultdict
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from ..engine import (
     RequestId,

--- a/serve/mlc_serve/model/sampler.py
+++ b/serve/mlc_serve/model/sampler.py
@@ -546,8 +546,6 @@ def get_loglikelihood_logprob_infos(
 def loglikelihood_sample(
     logits: torch.Tensor,
 ) -> List[Optional[RawLogprobsInfo]]:
-    logits = torch.from_dlpack(logits)
-
     # TODO(vvchernov): we need token_ids from input
     # It is not neccessary top1
     res = torch.argmax(logits, -1)

--- a/serve/mlc_serve/model/tvm_model.py
+++ b/serve/mlc_serve/model/tvm_model.py
@@ -413,7 +413,7 @@ class Model:
                     input_ids,
                     positions,
                     seq_lens,
-                    cache.cache_blocks,
+                    self.cache_blocks,
                     slot_mapping,
                     all_logits,
                     self.params,

--- a/serve/mlc_serve/model/tvm_model.py
+++ b/serve/mlc_serve/model/tvm_model.py
@@ -243,7 +243,7 @@ class Model:
         # Prepare sampling tensors in another stream to overlap
         # CPU<->GPU data transfer with GPU computation in forward pass.
         with torch.cuda.stream(self._copy_stream):
-            sampling_metadata = SamplingState.from_sampling_params(
+            sampling_state = SamplingState.from_sampling_params(
                 sampling_params,
                 past_decode_tokens,
                 self.torch_dtype,
@@ -302,7 +302,7 @@ class Model:
             last_query_logits,
             sequence_ids,
             requests,  # type: ignore
-            sampling_metadata,
+            sampling_state,
             self.vocab_size,
             self._copy_stream,
             self.torch_dtype,
@@ -370,7 +370,7 @@ class Model:
         # Prepare sampling tensors in another stream to overlap
         # CPU<->GPU data transfer with GPU computation in forward pass.
         with torch.cuda.stream(self._copy_stream):
-            sampling_metadata = SamplingState.from_sampling_params(
+            sampling_state = SamplingState.from_sampling_params(
                 sampling_params,
                 past_decode_tokens,
                 self.torch_dtype,
@@ -497,7 +497,7 @@ class Model:
                 logits,
                 sequence_ids,
                 requests,
-                sampling_metadata,
+                sampling_state,
                 self.vocab_size,
                 self._copy_stream,
                 self.torch_dtype,

--- a/serve/mlc_serve/model/tvm_model.py
+++ b/serve/mlc_serve/model/tvm_model.py
@@ -347,7 +347,7 @@ class Model:
                 request_past_decode_tokens = [self.vocab_size]
             elif isinstance(request, LoglikelihoodRequest):
                 seq_id = get_prompt_sequence_id(request.request_id)
-                # TODO(vvchernov): it it needed?
+                # TODO(vvchernov): is it needed?
                 request_past_decode_tokens = [self.vocab_size]
             elif isinstance(request, DecodeRequest):
                 seq_id = request.sequence_id

--- a/serve/tests/unittest/test_sampler.py
+++ b/serve/tests/unittest/test_sampler.py
@@ -8,13 +8,13 @@ dev = "cuda"
 vocab_size = 32000
 
 
-def get_sampling_metadata(sampling_params, past_output_tokens=None):
+def get_sampling_state(sampling_params, past_output_tokens=None):
     batch_size = len(sampling_params)
     if past_output_tokens is None:
         past_output_tokens = [[] for _ in range(batch_size)]
     _copy_stream: torch.cuda.Stream = torch.cuda.Stream()
     with torch.cuda.stream(_copy_stream):
-        sampling_metadata = SamplingState.from_sampling_params(
+        sampling_state = SamplingState.from_sampling_params(
             sampling_params,
             list_past_output_tokens=past_output_tokens,
             dtype=dtype,
@@ -22,7 +22,7 @@ def get_sampling_metadata(sampling_params, past_output_tokens=None):
             vocab_size=vocab_size,
         )
     torch.cuda.current_stream().wait_stream(_copy_stream)
-    return sampling_metadata
+    return sampling_state
 
 
 def _test_temperature(temp=0, batch_size=1):
@@ -32,10 +32,10 @@ def _test_temperature(temp=0, batch_size=1):
         temperature=temp,
     )
 
-    sampling_metadata = get_sampling_metadata([sampling_param])
+    sampling_state = get_sampling_state([sampling_param])
 
     expected = logits / temp if abs(temp) > SAMPLING_EPS else logits
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     assert torch.allclose(expected, new_logits)
 
 
@@ -44,36 +44,36 @@ def _test_logit_bias_checker():
     with pytest.raises(ValueError):
         logit_bias = {1: 2, 3: 105, 2: 2}
         sampling_param = SamplingParams(logit_bias=logit_bias)
-        get_sampling_metadata([sampling_param])
+        get_sampling_state([sampling_param])
 
     with pytest.raises(ValueError):
         logit_bias = {1: 99, 3: -101, 2: 2}
         sampling_param = SamplingParams(logit_bias=logit_bias)
-        get_sampling_metadata([sampling_param])
+        get_sampling_state([sampling_param])
 
     logit_bias = {1: 100, 3: -100, 2: 2}
     sampling_param = SamplingParams(logit_bias=logit_bias)
-    get_sampling_metadata([sampling_param])
+    get_sampling_state([sampling_param])
 
     # TODO(@team): it seems like the valid range is [1,vocab_size]. Double check.
     logit_bias = {1: 10, 3: -10, vocab_size: 2}
     sampling_param = SamplingParams(logit_bias=logit_bias)
-    get_sampling_metadata([sampling_param])
+    get_sampling_state([sampling_param])
 
     with pytest.raises(ValueError):
         logit_bias = {0: 10, 3: -10}
         sampling_param = SamplingParams(logit_bias=logit_bias)
-        get_sampling_metadata([sampling_param])
+        get_sampling_state([sampling_param])
 
     with pytest.raises(ValueError):
         logit_bias = {1: 10, 3: -10, vocab_size + 100: 2}
         sampling_param = SamplingParams(logit_bias=logit_bias)
-        get_sampling_metadata([sampling_param])
+        get_sampling_state([sampling_param])
 
     with pytest.raises(ValueError):
         logit_bias = {1: 10, -1: -10}
         sampling_param = SamplingParams(logit_bias=logit_bias)
-        get_sampling_metadata([sampling_param])
+        get_sampling_state([sampling_param])
 
 
 def _test_logit_bias():
@@ -83,12 +83,12 @@ def _test_logit_bias():
     logits = torch.rand(shape, dtype=dtype, device=dev)
     logit_bias = {1: -1, 3: 1, 2: 2}
     sampling_param = SamplingParams(logit_bias=logit_bias)
-    sampling_metadata = get_sampling_metadata([sampling_param])
+    sampling_state = get_sampling_state([sampling_param])
 
     expected = torch.clone(logits)
     for idx, val in logit_bias.items():
         expected[0][idx - 1] += val
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     assert torch.allclose(expected, new_logits)
 
     # test multi-batch
@@ -99,39 +99,39 @@ def _test_logit_bias():
     sampling_params = [
         SamplingParams(logit_bias=logit_bias) for logit_bias in list_logit_bias
     ]
-    sampling_metadata = get_sampling_metadata(sampling_params)
+    sampling_state = get_sampling_state(sampling_params)
 
     expected = torch.clone(logits)
     for batch_size in range(batch_size):
         logit_bias = list_logit_bias[batch_size]
         for idx, val in logit_bias.items():
             expected[batch_size][idx - 1] += val
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     assert torch.allclose(expected, new_logits)
 
 
 def _test_penalties_checker():
-    get_sampling_metadata([SamplingParams(presence_penalty=-1.0)])
-    get_sampling_metadata([SamplingParams(frequency_penalty=-1.0)])
-    get_sampling_metadata([SamplingParams(repetition_penalty=0.7)])
+    get_sampling_state([SamplingParams(presence_penalty=-1.0)])
+    get_sampling_state([SamplingParams(frequency_penalty=-1.0)])
+    get_sampling_state([SamplingParams(repetition_penalty=0.7)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(presence_penalty=-2.1)])
+        get_sampling_state([SamplingParams(presence_penalty=-2.1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(frequency_penalty=-2.1)])
+        get_sampling_state([SamplingParams(frequency_penalty=-2.1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(repetition_penalty=-2.1)])
+        get_sampling_state([SamplingParams(repetition_penalty=-2.1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(presence_penalty=2.1)])
+        get_sampling_state([SamplingParams(presence_penalty=2.1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(frequency_penalty=2.1)])
+        get_sampling_state([SamplingParams(frequency_penalty=2.1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata(
+        get_sampling_state(
             [
                 SamplingParams(frequency_penalty=1.1),
                 SamplingParams(repetition_penalty=2.1),
@@ -187,10 +187,10 @@ def _test_penalties():
             frequency_penalty=frequency_penalties[0],
         )
     ]
-    sampling_metadata = get_sampling_metadata(
+    sampling_state = get_sampling_state(
         sampling_param, past_output_tokens=past_output_tokens
     )
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     assert torch.allclose(expected, new_logits)
 
     batch_size = 3
@@ -212,34 +212,34 @@ def _test_penalties():
         )
         for i in range(batch_size)
     ]
-    sampling_metadata = get_sampling_metadata(
+    sampling_state = get_sampling_state(
         sampling_params, past_output_tokens=past_output_tokens
     )
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     assert torch.allclose(expected, new_logits)
 
 
 def _test_top_p_top_k_checker():
-    get_sampling_metadata([SamplingParams(top_p=0.8)])
-    get_sampling_metadata([SamplingParams(top_k=3)])
+    get_sampling_state([SamplingParams(top_p=0.8)])
+    get_sampling_state([SamplingParams(top_k=3)])
 
-    get_sampling_metadata([SamplingParams(top_k=-1)])
-    get_sampling_metadata([SamplingParams(top_k=1)])
-
-    with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(top_p=0.0)])
+    get_sampling_state([SamplingParams(top_k=-1)])
+    get_sampling_state([SamplingParams(top_k=1)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(top_p=-0.8)])
+        get_sampling_state([SamplingParams(top_p=0.0)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(top_k=0)])
+        get_sampling_state([SamplingParams(top_p=-0.8)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(top_k=0.8)])
+        get_sampling_state([SamplingParams(top_k=0)])
 
     with pytest.raises(ValueError):
-        get_sampling_metadata([SamplingParams(top_k=-2)])
+        get_sampling_state([SamplingParams(top_k=0.8)])
+
+    with pytest.raises(ValueError):
+        get_sampling_state([SamplingParams(top_k=-2)])
 
 
 def _test_top_p_top_k():
@@ -295,8 +295,8 @@ def _test_top_p_top_k():
     sampling_params = [
         SamplingParams(top_p=top_p, top_k=top_k) for _ in range(batch_size)
     ]
-    sampling_metadata = get_sampling_metadata(sampling_params)
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    sampling_state = get_sampling_state(sampling_params)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     expected = logits.clone()
     expected = get_expected_result(expected, top_pks=[(top_p, top_k)])
     assert torch.allclose(expected, new_logits)
@@ -308,9 +308,9 @@ def _test_top_p_top_k():
     sampling_params = [
         SamplingParams(top_p=top_p, top_k=top_k) for top_p, top_k in top_pks
     ]
-    sampling_metadata = get_sampling_metadata(sampling_params)
+    sampling_state = get_sampling_state(sampling_params)
 
-    new_logits = adjust_logits(logits, sampling_metadata, vocab_size)
+    new_logits = adjust_logits(logits, sampling_state, vocab_size)
     expected = logits.clone()
     expected = get_expected_result(expected, top_pks)
     # TODO(team): this is currently broken. Need to fix.


### PR DESCRIPTION
Loglikelihood approach is needed to check accuracy of a model on popular datasets and tasks like MMLU and BigBench. Particularly HuggingFace leaderboard bases on such tasks only.

**Notes:**
1. The branch bases on the work branch of #82, the latter PR should be merged before it.
2. Loglikelihood requires sequence of logits after prefill-like inference. But in mlc-llm on the model topology side the last logits set is splitted from all. I've added all logits to output tuple on llama topology side for multi-batch implementation.