### PR TITLE
Protect against engine initialization failure

### DIFF
--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -53,16 +53,20 @@ class StagingInferenceEngine(ScopedInferenceEngine):
         self.command_queue = self.mp_context.Queue()
         self.result_queue = self.mp_context.Queue(maxsize=1)
         self.ready_event = self.mp_context.Event()
-        self.worker_process = self.mp_context.Process(
-            target=run_generation_loop_worker,
-            args=(
-                model_module_loader,
-                model_module_loader_kwargs,
-                self.command_queue,
-                self.result_queue,
-                self.ready_event,
-            ),
-        )
+
+        try:
+            self.worker_process = self.mp_context.Process(
+                target=run_generation_loop_worker,
+                args=(
+                    model_module_loader,
+                    model_module_loader_kwargs,
+                    self.command_queue,
+                    self.result_queue,
+                    self.ready_event,
+                ),
+            )
+        except:
+            raise RuntimeError("Failed to initialize StagingInferenceEngine.")
 
     def start(self):
         self.worker_process.start()

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional, Union, Any
 
 from .base import FinishReason, RequestId, RequestState
 from .model_module import DecodeRequest, ModelModule, PrefillRequest, SequenceId
-import structlog
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Also reduced the engine init timeout by half so that we don't have to wait too long if the engine init did fail.

@jroesch 