### PR TITLE
Disallow direct configuration of `max_num_batched_tokens`

### DIFF
--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -101,7 +101,6 @@ def create_engine_and_tokenizer_module(
 ):
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
-        "max_num_batched_tokens": args.max_num_batched_tokens, 
         "max_input_len": args.max_input_len,    
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
@@ -179,7 +178,6 @@ if __name__ == "__main__":
     parser.add_argument("--local-id", type=str, required=True)
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--use-staging-engine", action="store_true")
-    parser.add_argument("--max-num-batched-tokens", type=int, default=-1)
     parser.add_argument("--max-input-len", type=int, default=-1)
     parser.add_argument("--min-decode-steps", type=int, default=32)
     parser.add_argument("--max-decode-steps", type=int, default=56)

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -101,6 +101,7 @@ def create_engine_and_tokenizer_module(
 ):
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
+        "max_num_sequences": args.max_num_sequences,
         "max_input_len": args.max_input_len,    
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
@@ -178,7 +179,8 @@ if __name__ == "__main__":
     parser.add_argument("--local-id", type=str, required=True)
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--use-staging-engine", action="store_true")
-    parser.add_argument("--max-input-len", type=int, default=-1)
+    parser.add_argument("--max-num-sequences", type=int, default=8)
+    parser.add_argument("--max-input-len", type=int, default=512)
     parser.add_argument("--min-decode-steps", type=int, default=32)
     parser.add_argument("--max-decode-steps", type=int, default=56)
     parser.add_argument("--prompt-allocate-ratio", type=float, default=2.0)

--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -704,7 +704,6 @@ class PagedCacheModelModule:
         model_artifact_path: str,
         engine_config: MLCServeEngineConfig,
     ):
-        max_num_batched_tokens, max_input_len = engine_config.max_num_batched_tokens, engine_config.max_input_len
         model_artifact_config = get_model_artifact_config(model_artifact_path)
 
         dev = tvm.device("cuda", 0)
@@ -717,14 +716,10 @@ class PagedCacheModelModule:
         num_kv_heads = model_artifact_config.num_key_value_heads // model_artifact_config.num_shards
         head_size = model_artifact_config.hidden_size // model_artifact_config.num_attention_heads
 
-        if max_num_batched_tokens > 0:
-            assert max_input_len > 0
-            assert max_num_batched_tokens % max_input_len == 0  # for simplicity
-
-            num_seqs = max_num_batched_tokens // max_input_len
+        if engine_config.max_num_batched_tokens > 0:
             num_blocks = get_num_cache_blocks(
                 model,
-                [max_input_len] * num_seqs,
+                [engine_config.max_input_len] * engine_config.max_num_sequences,
                 model_artifact_config.num_hidden_layers,
                 num_kv_heads,
                 head_size,

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -33,7 +33,6 @@ def test(args: argparse.Namespace):
 
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
-        "max_num_batched_tokens": args.max_num_batched_tokens, 
         "max_input_len": args.max_input_len,    
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
@@ -120,7 +119,6 @@ if __name__ == "__main__":
     parser.add_argument("--local-id", type=str, required=True)
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--num-shards", type=int, default=1)
-    parser.add_argument("--max-num-batched-tokens", type=int, default=-1)
     parser.add_argument("--max-input-len", type=int, default=-1)
     parser.add_argument("--max-output-len", type=int, default=20)
     parser.add_argument("--prompt-allocate-ratio", type=float, default=2.0)

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -33,6 +33,7 @@ def test(args: argparse.Namespace):
 
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
+        "max_num_sequences": args.max_num_sequences,
         "max_input_len": args.max_input_len,    
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
@@ -119,7 +120,8 @@ if __name__ == "__main__":
     parser.add_argument("--local-id", type=str, required=True)
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--num-shards", type=int, default=1)
-    parser.add_argument("--max-input-len", type=int, default=-1)
+    parser.add_argument("--max-input-len", type=int, default=512)
+    parser.add_argument("--max-num-sequences", type=int, default=8)
     parser.add_argument("--max-output-len", type=int, default=20)
     parser.add_argument("--prompt-allocate-ratio", type=float, default=2.0)
     parser.add_argument("--long-prompt", action="store_true")

--- a/serve/tests/unittest/test_engine_with_samplers.py
+++ b/serve/tests/unittest/test_engine_with_samplers.py
@@ -22,13 +22,13 @@ from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModel
 def create_engine(
         model_artifact_path, 
         use_staging_engine, 
-        max_num_batched_tokens, 
+        max_num_sequences, 
         max_input_len,
         
     ):
     engine_config = get_engine_config({
         "use_staging_engine": use_staging_engine,
-        "max_num_batched_tokens": max_num_batched_tokens, 
+        "max_num_sequences": max_num_sequences, 
         "max_input_len": max_input_len,    
         # Use defaults for "min_decode_steps", "max_decode_steps", "prompt_allocate_ratio"
     })
@@ -68,8 +68,8 @@ def create_request(idx, prompt, temp, max_tokens, stop, ignore_eos):
 def test_max_tokens(
         model_artifact_path, 
         use_staging_engine, 
-        max_num_batched_tokens=2560, 
-        max_input_len=2560,
+        max_num_sequences=4, 
+        max_input_len=512,
         num_requests=5,
         ignore_eos=False
     ):
@@ -77,7 +77,7 @@ def test_max_tokens(
     engine = create_engine(
         model_artifact_path, 
         use_staging_engine, 
-        max_num_batched_tokens, 
+        max_num_sequences, 
         max_input_len,
     )
 
@@ -105,15 +105,15 @@ def test_max_tokens(
 def test_ignore_eos(
     model_artifact_path, 
     use_staging_engine, 
-    max_num_batched_tokens=2560, 
-    max_input_len=2560,
+    max_num_sequences=4, 
+    max_input_len=512,
     num_requests=5,
 ):
     prompt = "hi"
     engine = create_engine(
         model_artifact_path, 
         use_staging_engine, 
-        max_num_batched_tokens, 
+        max_num_sequences, 
         max_input_len,
     )
     s = 113
@@ -141,15 +141,15 @@ def test_ignore_eos(
 def test_stop(
     model_artifact_path,
     use_staging_engine,
-    max_num_batched_tokens=2560,
-    max_input_len=2560,
+    max_num_sequences=4, 
+    max_input_len=512,
     num_requests=5,
 ):
     prompt = "Write a merge sort program in Python."
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_batched_tokens,
+        max_num_sequences,
         max_input_len,
     )
     ignore_eos = False


### PR DESCRIPTION
Instead, we use `max_num_sequences` and `max_input_len` since it is more intuitive. 

cc. @masahi 