### PR TITLE
Update logging config in benchmark and server launcher

### DIFF
--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -17,9 +17,7 @@ from mlc_serve.engine import (
 from mlc_serve.engine.staging_engine import StagingInferenceEngine
 from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
 from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
-from mlc_serve.run import setup_logging
-
-from mlc_llm import utils
+from mlc_serve.logging_utils import configure_logging
 
 
 def sample_requests(
@@ -102,7 +100,7 @@ def create_engine_and_tokenizer_module(
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
         "max_num_sequences": args.max_num_sequences,
-        "max_input_len": args.max_input_len,    
+        "max_input_len": args.max_input_len,
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
         "prompt_allocate_ratio": args.prompt_allocate_ratio
@@ -196,7 +194,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--debug-logging", action="store_true")
     args = parser.parse_args()
-    setup_logging(args)
+
+    log_level = "DEBUG" if args.debug_logging else "INFO"
+    configure_logging(enable_json_logs=False, log_level=log_level)
 
     args.model_artifact_path = os.path.join(args.artifact_path, args.local_id)
     if not os.path.exists(args.model_artifact_path):

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -174,7 +174,7 @@ class StagingInferenceEngine(ScopedInferenceEngine):
 
         outputs = list[RequestOutput]()
         with self.requests_lock:
-            # LOG.debug("StagingInferenceEngine.step obtained requests_lock", generation_output=generation_output)
+            LOG.debug("StagingInferenceEngine.step obtained requests_lock", generation_output=generation_output)
             for seq_output in generation_output.sequences:
                 # TODO: support multi-sequence per request
                 request_id = seq_output.id.request_id

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -87,7 +87,7 @@ def create_engine(
 
 def run_server():
     args = parse_args()
-    setup_logging(args)
+
     log_level = "DEBUG" if args.debug_logging else "INFO"
     configure_logging(enable_json_logs=True, log_level=log_level)
 

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -10,6 +10,7 @@ from .engine import AsyncEngineConnector, get_engine_config
 from .engine.staging_engine import StagingInferenceEngine
 from .engine.sync_engine import SynchronousInferenceEngine
 from .model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
+from .logging_utils import configure_logging
 
 
 def parse_args():
@@ -41,45 +42,14 @@ def parse_args():
     return parsed
 
 
-def setup_logging(args):
-    level = "INFO"
-    if args.debug_logging:
-        level = "DEBUG"
-
-    logging_config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "standard": {
-                "format": "%(asctime)s [%(levelname)s] - %(name)s - %(message)s",
-            },
-        },
-        "handlers": {
-            "console": {
-                "level": level,  # Set the handler's log level to DEBUG
-                "class": "logging.StreamHandler",
-                "formatter": "standard",
-            },
-        },
-        "root": {
-            "handlers": ["console"],
-            "level": level,  # Set the logger's log level to DEBUG
-        },
-        "mlc_serve.engine.sync_engine": {"level": level},
-        "mlc_serve.engine.staging_engine": {"level": level},
-        "mlc_serve.engine.staging_engine_worker": {"level": level},
-    }
-    logging.config.dictConfig(logging_config)
-
-
 def create_engine(
     args: argparse.Namespace,
 ):
     """
       `model_artifact_path` has the following structure
       |- compiled artifact (.so)
-      |- `build_config.json`: stores compile-time info, such as `num_shards` and `quantization`. 
-      |- params/ : stores weights in mlc format and `ndarray-cache.json`. 
+      |- `build_config.json`: stores compile-time info, such as `num_shards` and `quantization`.
+      |- params/ : stores weights in mlc format and `ndarray-cache.json`.
       |            `ndarray-cache.json` is especially important for Disco.
       |- model/ : stores info from hf model cards such as max context length and tokenizer
     """
@@ -91,12 +61,12 @@ def create_engine(
     engine_config = get_engine_config({
         "use_staging_engine": args.use_staging_engine,
         "max_num_sequences": args.max_num_sequences,
-        "max_input_len": args.max_input_len,    
+        "max_input_len": args.max_input_len,
         "min_decode_steps": args.min_decode_steps,
         "max_decode_steps": args.max_decode_steps,
         "prompt_allocate_ratio": args.prompt_allocate_ratio
     })
-  
+
     if args.use_staging_engine:
         return StagingInferenceEngine(
             tokenizer_module=HfTokenizerModule(model_artifact_path),
@@ -118,6 +88,8 @@ def create_engine(
 def run_server():
     args = parse_args()
     setup_logging(args)
+    log_level = "DEBUG" if args.debug_logging else "INFO"
+    configure_logging(enable_json_logs=True, log_level=log_level)
 
     engine = create_engine(args)
     connector = AsyncEngineConnector(engine)


### PR DESCRIPTION
Following https://github.com/octoml/mlc-llm/pull/85#discussion_r1404621919, re-enable the debug log that was temp disabled in #85 and also update the benchmark and `serve/run.py` to use the new logging infra.

@sunggg 