### PR TITLE
Add more annotations to mlc-serve

### DIFF
--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -132,7 +132,7 @@ class AsyncEngineConnector:
         for item in result.outputs:
             request_id = item.request_id
             if request_id not in self.result_queues:
-                logging.warning(
+                LOG.warn(
                     f"Unknown request id when dispatching result: {request_id}"
                 )
                 continue

--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from abc import ABC, abstractmethod
 
-from typing import List, Callable, Any, Optional
-import json
+from typing import List, Callable, Any, Optional, Dict
 import inspect
 
 from .sampling_params import SamplingParams, SamplingType
@@ -31,7 +30,7 @@ class MLCServeEngineConfig:
     prompt_allocate_ratio: float = 2.0
 
     @classmethod
-    def _from_json(config_cls, json_obj: dict):
+    def _from_json(config_cls, json_obj: Dict[Any, Any]):
         return config_cls(
             **{
                 k: v
@@ -106,7 +105,7 @@ ValidateTokensCallback = Callable[["Request", List[Token]], ValidationError]
 @dataclass
 class Request:
     request_id: RequestId
-    messages: list[ChatMessage]
+    messages: List[ChatMessage]
     # Number of sequences to generate
     num_sequences: int = 1
     # TODO: should `best_of` be handled in the serving layer?

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -4,7 +4,8 @@ Required interfaces for the actual inference capability in InferenceEngine.
 from dataclasses import dataclass
 from typing import Optional, Protocol, Union
 
-from .base import ChatMessage, RequestId
+from .base import ChatMessage, RequestId, MLCServeEngineConfig
+from ..model.base import ModelArtifactConfig
 from .sampling_params import SamplingParams
 
 
@@ -180,5 +181,5 @@ class TokenizerModule(Protocol):
 
 
 class ModelModule(TextTokenGeneratorModule, TokenizerModule):
-    pass
-
+    model_artifact_config: ModelArtifactConfig
+    engine_config: MLCServeEngineConfig

--- a/serve/mlc_serve/logging_utils.py
+++ b/serve/mlc_serve/logging_utils.py
@@ -2,6 +2,7 @@
 import logging
 import sys
 from typing import List, Dict, Tuple, Any
+from psutil import Process
 
 import structlog
 from structlog.types import EventDict
@@ -12,7 +13,7 @@ _JSON = False
 
 def json_logging_enabled() -> bool:
     global _JSON
-    return
+    return _JSON
 
 
 def configure_logging(enable_json_logs: bool = False, log_level: str = "INFO"):
@@ -53,13 +54,13 @@ def configure_logging(enable_json_logs: bool = False, log_level: str = "INFO"):
         cache_logger_on_first_use=True,
     )
 
-    logs_render = (
+    logs_render: Processor = (
         structlog.processors.JSONRenderer()
         if enable_json_logs
         else structlog.dev.ConsoleRenderer(colors=True)
     )
 
-    extra_processors = []
+    extra_processors: List[Processor] = []
     # extra_processors = [StructureVLLMOutput()]
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=shared_processors + extra_processors,

--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -16,7 +16,7 @@ from tvm.runtime import disco as di
 from mlc_llm import utils
 
 from .base import get_model_artifact_config
-from .tokenizer import HfTokenizerModule
+from .tokenizer import HfTokenizerModule, ConversationTemplate
 from ..engine import RequestId, SamplingType, MLCServeEngineConfig, SamplingParams
 from ..engine.model_module import (
     DecodeRequest,
@@ -24,6 +24,7 @@ from ..engine.model_module import (
     SequenceId,
     TextGenerationResult,
 )
+from ..engine.model_module import ModelModule
 
 LOG = structlog.stdlib.get_logger(__name__)
 
@@ -702,6 +703,12 @@ class PagedCacheModelTextGenerator:
 
 
 class PagedCacheModelModule:
+    engine_config: MLCServeEngineConfig
+    text_generator: PagedCacheModelTextGenerator
+    cache_manager: CacheManager
+    tokenizer: HfTokenizerModule
+    conversation_template: ConversationTemplate
+
     def __init__(
         self,
         model_artifact_path: str,
@@ -765,3 +772,6 @@ class PagedCacheModelModule:
         tokenizer_module = HfTokenizerModule(model_artifact_path)
         self.tokenizer = tokenizer_module.tokenizer
         self.conversation_template = tokenizer_module.conversation_template
+
+    def _check_implements_model_module(self) -> ModelModule:
+        return self

--- a/serve/mlc_serve/model/tokenizer.py
+++ b/serve/mlc_serve/model/tokenizer.py
@@ -1,16 +1,18 @@
+from typing import List
 from transformers import AutoTokenizer
 import os
 from ..engine import ChatMessage
+from pathlib import Path
 
 class Tokenizer:
     def __init__(self, hf_tokenizer):
         self._tokenizer = hf_tokenizer
         self.eos_token_id = self._tokenizer.eos_token_id
 
-    def encode(self, text: str) -> list[int]:
+    def encode(self, text: str) -> List[int]:
         return self._tokenizer.encode(text)
 
-    def decode(self, tokens: list[int]) -> str:
+    def decode(self, tokens: List[int]) -> str:
         return self._tokenizer.decode(tokens, skip_special_tokens=True)
 
 
@@ -30,9 +32,9 @@ class ConversationTemplate:
 
 
 class HfTokenizerModule:
-    def __init__(self, model_artifact_path: str):
+    def __init__(self, model_artifact_path: Path):
         hf_tokenizer = AutoTokenizer.from_pretrained(
-            os.path.join(model_artifact_path, "model"),
+            model_artifact_path.joinpath("model"),
             trust_remote_code=False,
         )
         self.tokenizer = Tokenizer(hf_tokenizer)


### PR DESCRIPTION
Ideally I would like to turn on MyPy checking for the entire code base, and oLLM soon ™. Usually these type errors catch missing validation/checks or logic issues. I added this many annotations so the oLLM code base can type check just the uses of the code inside of `oLLM`. We also need to make sure to include the `typed.py` file when we do `setup.py` or people who install the package will not be able to get type annotations. 

