### PR TITLE
Support Emoji w/o Perf Regression

### DIFF
--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -271,8 +271,8 @@ class GenerationSequence:
     generated_token_ids: list[int]
     next_start_position: int
     output_text: str
-    prefix_offset: int = 0
-    read_offset: int = 0
+    prefix_begin_offset: int = 0
+    new_prefix_end_offset: int = 0
     prev_tokens: Optional[List[str]] = None
     is_finished: bool = False
 

--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -271,6 +271,9 @@ class GenerationSequence:
     generated_token_ids: list[int]
     next_start_position: int
     output_text: str
+    prefix_offset: int = 0
+    read_offset: int = 0
+    prev_tokens: Optional[List[str]] = None
     is_finished: bool = False
 
 

--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -272,7 +272,7 @@ class GenerationSequence:
     next_start_position: int
     output_text: str
     prefix_begin_offset: int = 0
-    new_prefix_end_offset: int = 0
+    prefix_end_offset: int = 0
     prev_tokens: Optional[List[str]] = None
     is_finished: bool = False
 

--- a/serve/mlc_serve/engine/engine_common.py
+++ b/serve/mlc_serve/engine/engine_common.py
@@ -20,7 +20,6 @@ from .base import (
 from .model_module import (
     DecodeRequest,
     PrefillRequest,
-    Tokenizer,
     ConversationTemplate,
     KVCacheManager,
     ModelModule,
@@ -33,7 +32,7 @@ LOG = structlog.stdlib.get_logger(__name__)
 
 
 def get_new_request_state(
-    request: Request, conversation_template: ConversationTemplate, tokenizer: Tokenizer
+    request: Request, conversation_template: ConversationTemplate, tokenizer: TokenizerP
 ) -> RequestState:
     if request.debug_options.prompt is not None:
         prompt = request.debug_options.prompt
@@ -72,7 +71,7 @@ def get_new_request_state(
 def detokenize_incrementally(
     prompt_tokens: list[int],
     generation_sequence: GenerationSequence,
-    tokenizer: Tokenizer,
+    tokenizer: TokenizerP,
     skip_special_tokens=False,
 ) -> str:
     new_token_id = generation_sequence.generated_token_ids[-1]
@@ -155,7 +154,7 @@ def update_sequence(
     gen_seq: GenerationSequence,
     new_token_ids: list[int],
     prompt_token_ids: list[int],
-    tokenizer: Tokenizer,
+    tokenizer: TokenizerP,
     stopping_criteria: StoppingCriteria,
 ) -> str:
     gen_seq.next_start_position = len(prompt_token_ids) + len(

--- a/serve/mlc_serve/engine/engine_common.py
+++ b/serve/mlc_serve/engine/engine_common.py
@@ -72,6 +72,72 @@ def decode_last_output(
     prompt_tokens: list[int],
     generation_sequence: GenerationSequence,
     tokenizer: Tokenizer,
+    skip_special_tokens=False,
+) -> str:
+    new_token_id = generation_sequence.generated_token_ids[-1]
+
+    LOG.info(f"out:{generation_sequence.output_text}")
+    # This is the first iteration for this sequence
+    if generation_sequence.prev_tokens is None:
+        assert len(generation_sequence.output_text) == 0
+        LOG.info("First iter")
+        # TODO(masahi): Figure out a way to remove this concat
+        all_input_ids = prompt_tokens + generation_sequence.generated_token_ids
+        new_tokens = tokenizer._tokenizer.convert_ids_to_tokens(
+            all_input_ids, skip_special_tokens=skip_special_tokens
+        )
+        output_tokens = new_tokens
+
+        # 5 is an arbitrary value that should work for all
+        # tokenizers (bigger = more conservative).
+        # Subtract 1 extra to account for the generated token.
+        prefix_offset = max(len(output_tokens) - 6, 0)
+        read_offset = max(len(output_tokens) - 1, 0)
+    else:
+        LOG.info("Second iter")
+        # Put new_token_id in a list so skip_special_tokens is respected
+        new_tokens = tokenizer._tokenizer.convert_ids_to_tokens(
+            [new_token_id], skip_special_tokens=skip_special_tokens
+        )
+        output_tokens = generation_sequence.prev_tokens + new_tokens
+
+        prefix_offset = generation_sequence.prefix_offset
+        read_offset = generation_sequence.read_offset
+
+    assert tokenizer._tokenizer.is_fast
+
+    prefix_text = tokenizer._tokenizer.convert_tokens_to_string(
+        output_tokens[prefix_offset:read_offset]
+    )
+    new_text = tokenizer._tokenizer.convert_tokens_to_string(
+        output_tokens[prefix_offset:]
+    )
+    LOG.info(f"prefix_offset:{prefix_offset}, read_offset:{read_offset}")
+    LOG.info(
+        f"prefix ({len(prefix_text)}): {prefix_text}, new_text({len(new_text)}): {new_text}"
+    )
+
+    if len(new_text) > len(prefix_text) and not new_text.endswith("�"):
+        # utf-8 char at the end means it's a potential unfinished byte sequence
+        # from byte fallback tokenization.
+        # If it's in the middle, it's probably a real invalid id generated
+        # by the model
+        generation_sequence.prev_tokens = new_tokens
+        generation_sequence.prefix_offset = read_offset
+        generation_sequence.read_offset = len(output_tokens)
+        return new_text[len(prefix_text) :]
+    else:
+        generation_sequence.prev_tokens = new_tokens
+        generation_sequence.prefix_offset = prefix_offset
+        generation_sequence.read_offset = read_offset
+        return ""
+
+
+"""
+def decode_last_output(
+    prompt_tokens: list[int],
+    generation_sequence: GenerationSequence,
+    tokenizer: Tokenizer,
 ) -> str:
     if len(generation_sequence.output_text):
         prefix_idx = max(0, generation_sequence.next_start_position - 6)
@@ -90,6 +156,8 @@ def decode_last_output(
     full = tokenizer.decode(token_ids[prefix_idx:])
 
     return full[len(prefix) :]
+
+"""
 
 
 def check_stopping_sequences(stopping_criteria, output_text, delta, is_ended):

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -134,7 +134,6 @@ class Tokenizer(Protocol):
     def encode(self, text: str) -> list[int]:
         pass
 
-    # TODO: Incremental decoding
     def decode(self, tokens: list[int]) -> str:
         pass
 

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -2,7 +2,7 @@
 Required interfaces for the actual inference capability in InferenceEngine.
 """
 from dataclasses import dataclass
-from typing import Optional, Protocol, Union
+from typing import Optional, Protocol, Union, List
 
 from .base import ChatMessage, RequestId, MLCServeEngineConfig, RequestState, SequenceId
 from ..model.base import ModelArtifactConfig
@@ -12,7 +12,7 @@ from .sampling_params import SamplingParams
 @dataclass
 class PrefillRequest:
     request_id: RequestId
-    token_ids: list[int]
+    token_ids: List[int]
     # Number of sequences to generate
     num_sequence: int
     sampling_params: SamplingParams
@@ -28,7 +28,7 @@ class PrefillRequest:
 class DecodeRequest:
     sequence_id: SequenceId
     # All tokens for this request, including prompt
-    token_ids: list[int]
+    token_ids: List[int]
     sampling_params: SamplingParams
 
 
@@ -41,7 +41,7 @@ class TextGenerationResult:
     sequence_id: SequenceId
     # for most cases, there should be only one token returned
     # making this a list of token ids to leave room for speculative decoding
-    generated_tokens: list[int]
+    generated_tokens: List[int]
     error: Optional[str]
 
 
@@ -116,9 +116,9 @@ class TextGenerator(Protocol):
 
     def generate(
         self,
-        requests: list[Union[PrefillRequest, DecodeRequest]],
+        requests: List[Union[PrefillRequest, DecodeRequest]],
         kv_cache: KVCache,
-    ) -> list[TextGenerationResult]:
+    ) -> List[TextGenerationResult]:
         """
         A unified entrypoint for text generation.
 
@@ -130,16 +130,25 @@ class TextGenerator(Protocol):
 
 class Tokenizer(Protocol):
     eos_token_id: int
+    skip_special_tokens: bool
+    all_special_ids: List[int]
+    is_fast: bool
 
-    def encode(self, text: str) -> list[int]:
-        pass
+    def encode(self, text: str) -> List[int]:
+        ...
 
-    def decode(self, tokens: list[int]) -> str:
-        pass
+    def decode(self, tokens: List[int]) -> str:
+        ...
+
+    def convert_ids_to_tokens(self, token_ids: List[int]) -> List[str]:
+        ...
+
+    def convert_tokens_to_string(self, tokens: List[str]) -> str:
+        ...
 
 
 class ConversationTemplate(Protocol):
-    def apply(self, messages: list[ChatMessage]) -> str:
+    def apply(self, messages: List[ChatMessage]) -> str:
         pass
 
 

--- a/serve/mlc_serve/model/tokenizer.py
+++ b/serve/mlc_serve/model/tokenizer.py
@@ -5,15 +5,28 @@ from pathlib import Path
 
 
 class Tokenizer:
-    def __init__(self, hf_tokenizer):
+    def __init__(self, hf_tokenizer, skip_special_tokens=True):
         self._tokenizer = hf_tokenizer
         self.eos_token_id = self._tokenizer.eos_token_id
+        self.skip_special_tokens = skip_special_tokens
+        self.all_special_ids = self._tokenizer.all_special_ids
+        self.is_fast = self._tokenizer.is_fast
 
     def encode(self, text: str) -> List[int]:
         return self._tokenizer.encode(text)
 
-    def decode(self, tokens: List[int]) -> str:
-        return self._tokenizer.decode(tokens, skip_special_tokens=True)
+    def decode(self, token_ids: List[int]) -> str:
+        return self._tokenizer.decode(
+            token_ids, skip_special_tokens=self.skip_special_tokens
+        )
+
+    def convert_ids_to_tokens(self, token_ids: List[int]) -> List[str]:
+        return self._tokenizer.convert_ids_to_tokens(
+            token_ids, skip_special_tokens=self.skip_special_tokens
+        )
+
+    def convert_tokens_to_string(self, tokens: List[str]) -> str:
+        return self._tokenizer.convert_tokens_to_string(tokens)
 
 
 class ConversationTemplate:


### PR DESCRIPTION
Follow-up on: https://github.com/octoml/mlc-llm/pull/104

Previous approach had to be reverted due to significant performance regression.
This PR is based on vllm/TGI's approach and no performance regression is observed in my local testing.

w/ llama 7b fp16 on A100,
Before: `Throughput: 10.96 requests/s, 5241.24 tokens/s`
After: `Throughput: 11.00 requests/s, 5259.99 tokens/s`
