### PR TITLE
Free params after converting in param loader

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -1735,7 +1735,8 @@ def get_model(args, hf_config):
     if args.max_seq_len != -1:
         config.max_sequence_length = args.max_seq_len
 
-    param_manager = ParamManager()
+    keep_params_after_load = args.quantization.name == "q4f16_ft"
+    param_manager = ParamManager(keep_params_after_load)
     bb = relax.BlockBuilder()
 
     bb.add_func(get_scatter_func(dtype), "scatter")

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -1735,7 +1735,7 @@ def get_model(args, hf_config):
     if args.max_seq_len != -1:
         config.max_sequence_length = args.max_seq_len
 
-    keep_params_after_load = args.quantization.name == "q4f16_ft"
+    keep_params_after_load = isinstance(config, MixtralConfig) and args.quantization.name == "q4f16_ft"
     param_manager = ParamManager(keep_params_after_load)
     bb = relax.BlockBuilder()
 

--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -203,7 +203,7 @@ class ParamManager:
     pidx2pname: Dict[int, str]
     torch_pname2binname: Dict[str, str]
 
-    def __init__(self) -> None:
+    def __init__(self, keep_params_after_load=False) -> None:
         self.params = {}
         self.param_names = []
         self.params_in_func = {}
@@ -218,6 +218,9 @@ class ParamManager:
         self.f_run_prequantize = None
 
         self.qspec_updater_classes = []
+
+        # this is a workaround only needed for mixtral q4f16_ft
+        self.keep_params_after_load = keep_params_after_load
 
     def register_params(
         self,
@@ -606,8 +609,9 @@ class ParamManager:
                     relax_pname,
                     [cached_torch_params[torch_pname] for torch_pname in torch_pnames],
                 )
-                # for torch_pname in torch_pnames:
-                    # del cached_torch_params[torch_pname]
+                if not self.keep_params_after_load:
+                    for torch_pname in torch_pnames:
+                        del cached_torch_params[torch_pname]
 
             assert i in cached_relax_params
             assert i not in loaded_idx_set


### PR DESCRIPTION
This is a workaround only needed for mixtral q4. Disabling it for other models.