### PR TITLE
Add vLLM and MII Deepspeed for Throughput Benchmarking 

### DIFF
--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -18,7 +18,7 @@ from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
 from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
 from mlc_serve.utils import get_default_mlc_serve_argparser, postproc_mlc_serve_args
 
-SAMPLER_SETTING = {"ignore_eos": True, "temperature": 1, "use_beam_search": False}
+SAMPLER_SETTING = {"ignore_eos": True, "temperature": 1}
 
 
 def sample_requests(
@@ -96,12 +96,11 @@ def run_vllm(requests: List[Tuple[str, int, int]], model, num_shards) -> float:
     for prompt, _, output_len in requests:
         sampling_params = SamplingParams(
             n=1,
-            use_beam_search=SAMPLER_SETTING["use_beam_search"],
+            use_beam_search=False,
             temperature=SAMPLER_SETTING["temperature"],
             ignore_eos=SAMPLER_SETTING["ignore_eos"],
             max_tokens=output_len,
         )
-        # FIXME(woosuk): Do not use internal method.
         llm._add_request(
             prompt=prompt,
             prompt_token_ids=None,

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -18,7 +18,8 @@ from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
 from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
 from mlc_serve.utils import get_default_mlc_serve_argparser, postproc_mlc_serve_args
 
-SAMPLER_SETTING = {"ignore_eos": True, "temperature": 1}
+# Temperature needs to be set based on the user arguments.
+SAMPLER_SETTING = {"ignore_eos": True, "temperature": -1}
 
 
 def sample_requests(
@@ -243,6 +244,9 @@ if __name__ == "__main__":
         "--num-prompts", type=int, default=1000, help="Number of prompts to process."
     )
     parser.add_argument(
+        "--greedy-sampling-ratio", type=float, default=0.5, help="Ratio of greedy sampling in the requests."
+    )
+    parser.add_argument(
         "--max-output-tokens",
         type=int,
         default=128,
@@ -287,5 +291,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     args = postproc_mlc_serve_args(args)
+
+    assert args.greedy_sampling_ratio >= 0.0 and  args.greedy_sampling_ratio <= 1.0
+    SAMPLER_SETTING["temperature"] = (0.0 if random.random() <= args.greedy_sampling_ratio else 1.0)
 
     main(args)

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -114,7 +114,7 @@ def run_vllm(requests: List[Tuple[str, int, int]], model, num_shards) -> float:
     return end - start
 
 
-def run_mlc(engine, requests) -> float:
+def run_mlc(engine, requests, num_sequences_to_sample) -> float:
     for i, (prompt, _, output_len) in enumerate(requests):
         engine.add(
             [
@@ -127,7 +127,7 @@ def run_mlc(engine, requests) -> float:
                     stopping_criteria=StoppingCriteria(
                         max_tokens=output_len, stop_sequences=None
                     ),
-                    num_sequences=1,
+                    num_sequences=num_sequences_to_sample,
                     debug_options=DebugOptions(
                         ignore_eos=SAMPLER_SETTING["ignore_eos"], prompt=prompt
                     ),
@@ -191,7 +191,7 @@ def main(args: argparse.Namespace):
         requests = sample_requests(
             args.dataset, args.num_prompts, engine.tokenizer._tokenizer
         )
-        elapsed_time = run_mlc(engine, requests)
+        elapsed_time = run_mlc(engine, requests, args.num_sequences_to_sample)
     else:
         from transformers import AutoTokenizer
 


### PR DESCRIPTION
This PR integrates vLLM and Deepspeed MII for the convenience of benchmarking. 
The usage:
```
python3 serve/benchmarks/benchmark_throughput.py --backend mlc-serve --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000 

python3 serve/benchmarks/benchmark_throughput.py --backend vllm --model /opt/models/mistral/mixtral-8x7b-instruct-v0.1 --num-shards 2 --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000 

python3 serve/benchmarks/benchmark_throughput.py --backend mii --model /opt/models/mistral/mixtral-8x7b-instruct-v0.1 --num-shards 2 --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000
```

Some performance result with new benchmark script.
Currently, I have a problem running Deepspeed MII with multi-gpu and vllm for Llama families. 
```
Mixtral 8x7B fp16 on 2xH100
* MLC-Serve, Engine Throughput: 23.52 requests/s, 8997.83 tokens/s
* vLLM, Engine Throughput: 13.35 requests/s, 5109.44 tokens/s
* MII, AssertionError: Attempting to run with TP > 1 and not using a distributed launcher like deepspeed or torch.distributed

Llama 13B fp16 on 1xH100
* MLC-Serve, Engine Throughput: 18.92 requests/s, 6830.19 tokens/s
* vLLM, cublas error
* MII, Engine Throughput: 14.79 requests/s, 5339.59 tokens/s
```

With this PR, you wouldn't be able to compare with the previous numbers because 
* This PR introduces `--greedy-sampling-ratio` to consider the performance of random sampling, which is more expensive path than greedy. Prior to this PR, the `--greedy-sampling-ratio` was 0.0.
* This PR introduces `--max-output-tokens` to force generation length globally since MII does not seem to support per-request max-output-tokens. 

The follow-up PR will bring latency benchmark. 