### PR TITLE
Fix staging engine finish reason

### DIFF
--- a/serve/mlc_serve/api/handler.py
+++ b/serve/mlc_serve/api/handler.py
@@ -218,12 +218,13 @@ async def collect_result_stream(
             if seq.index >= len(sequences):
                 raise RuntimeError(f"Unexpected sequence index: {seq.index}.")
             num_generated_tokens[seq.index] = seq.num_generated_tokens
+
+            if seq.delta:
+                sequences[seq.index].append(seq.delta)
+
             if seq.is_finished:
                 assert seq.finish_reason is not None
                 finish_reasons[seq.index] = seq.finish_reason.value  # type: ignore
-            else:
-                assert seq.delta is not None
-                sequences[seq.index].append(seq.delta)
 
     choices = [
         ChatCompletionResponseChoice(

--- a/serve/mlc_serve/engine/engine_common.py
+++ b/serve/mlc_serve/engine/engine_common.py
@@ -229,7 +229,7 @@ def get_requests_to_process(
     return requests, is_prompt_batch, token_counts
 
 
-def should_stop_seq_by_length(
+def should_stop_by_length(
     gen_seq: GenerationSequence,
     prompt_len: int,
     max_context_length: int,
@@ -250,24 +250,6 @@ def should_stop_seq_by_length(
         return True
 
     return False
-
-
-def should_stop_by_length(state: RequestState, max_context_length: int) -> bool:
-    # If all sequences have already finished, return False
-    if state.is_finished:
-        return False
-
-    for gen_seq in state.generation_sequences:
-        # If at least one of unfinished sequences shouldn't stop, the request shouldn't stop as well.
-        if not gen_seq.is_finished and not should_stop_seq_by_length(
-            gen_seq,
-            state.prompt_len,
-            max_context_length,
-            state.stopping_criteria.max_tokens,
-        ):
-            return False
-
-    return True
 
 
 class EngineBase:

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -228,18 +228,21 @@ class StagingInferenceEngine(ScopedInferenceEngine):
                         self.tokenizer,
                         state.stopping_criteria,
                     )
+                else:
+                    delta = None
 
-                    output = SequenceOutput(
-                        seq_output.id.sequence_index,
-                        delta,
-                        finish_reason=seq_output.finish_reason,
-                        num_generated_tokens=len(gen_seq.generated_token_ids),
-                    )
+                output = SequenceOutput(
+                    seq_output.id.sequence_index,
+                    delta,
+                    finish_reason=seq_output.finish_reason,
+                    num_generated_tokens=len(gen_seq.generated_token_ids),
+                )
 
-                    seq_outputs[request_id].append(output)
-                    prompt_len[request_id] = state.prompt_len
+                seq_outputs[request_id].append(output)
+                prompt_len[request_id] = state.prompt_len
 
                 if gen_seq.is_finished:
+                    print("Stop seq", gen_seq.seq_id)
                     self.stop_sequence(gen_seq.seq_id)
 
                 if seq_output.finish_reason is not None:

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -242,7 +242,6 @@ class StagingInferenceEngine(ScopedInferenceEngine):
                 prompt_len[request_id] = state.prompt_len
 
                 if gen_seq.is_finished:
-                    print("Stop seq", gen_seq.seq_id)
                     self.stop_sequence(gen_seq.seq_id)
 
                 if seq_output.finish_reason is not None:

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -246,6 +246,8 @@ class StagingInferenceEngine(ScopedInferenceEngine):
 
                 if seq_output.finish_reason is not None:
                     gen_seq.is_finished = True
+                else:
+                    gen_seq.is_finished = False
 
             for request_id, out_seqs in seq_outputs.items():
                 outputs.append(

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -181,13 +181,6 @@ class GenerationLoopWorker(EngineBase):
             gen_seq = self.sequence_map[seq_id]
             if not gen_seq.is_finished:
                 gen_seq.is_finished = True
-                outputs.append(
-                    SequenceGenerationOutput(
-                        id=seq_id,
-                        new_tokens=[],
-                        finish_reason=FinishReason.Stop,
-                    )
-                )
 
         self.stopped_sequences.clear()
 

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -6,7 +6,7 @@ import multiprocessing
 import multiprocessing.synchronize
 from dataclasses import dataclass
 from threading import Thread
-from typing import Callable, Optional, Union, Any, Dict, List, Set
+from typing import Callable, Optional, Union, Any, Dict, List
 
 import structlog
 
@@ -74,7 +74,7 @@ class GenerationLoopWorkerOutput:
 
 class GenerationLoopWorker(EngineBase):
     cancelled_requests: List[RequestState]
-    stopped_sequences: Set[SequenceId]
+    stopped_sequences: List[SequenceId]
     sequence_map: Dict[SequenceId, GenerationSequence]
     prom_metrics: PrometheusMetrics
     inv_kv_cache_size: float
@@ -86,7 +86,7 @@ class GenerationLoopWorker(EngineBase):
         EngineBase.__init__(self, model_module)
 
         self.cancelled_requests = list[RequestState]()
-        self.stopped_sequences = set[SequenceId]()
+        self.stopped_sequences = list[SequenceId]()
         self.sequence_map = dict[SequenceId, GenerationSequence]()
 
         self.prom_metrics = PrometheusMetrics()
@@ -133,7 +133,7 @@ class GenerationLoopWorker(EngineBase):
                 self.cancelled_requests.append(self.current_batch[request_id])
 
     def stop_sequence(self, sequence_id: SequenceId):
-        self.stopped_sequences.add(sequence_id)
+        self.stopped_sequences.append(sequence_id)
 
     def create_aborted_outputs(
         self,

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -179,14 +179,15 @@ class GenerationLoopWorker(EngineBase):
 
         for seq_id in self.stopped_sequences:
             gen_seq = self.sequence_map[seq_id]
-            gen_seq.is_finished = True
-            outputs.append(
-                SequenceGenerationOutput(
-                    id=seq_id,
-                    new_tokens=[],
-                    finish_reason=FinishReason.Stop,
+            if not gen_seq.is_finished:
+                gen_seq.is_finished = True
+                outputs.append(
+                    SequenceGenerationOutput(
+                        id=seq_id,
+                        new_tokens=[],
+                        finish_reason=FinishReason.Stop,
+                    )
                 )
-            )
 
         self.stopped_sequences.clear()
 

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -80,7 +80,6 @@ class GenerationLoopWorker(EngineBase):
     prom_metrics: PrometheusMetrics
     inv_kv_cache_size: float
 
-
     def __init__(
         self,
         model_module: ModelModule,
@@ -159,6 +158,7 @@ class GenerationLoopWorker(EngineBase):
                         error=err,
                     )
                 )
+                del self.sequence_map[gen_seq.seq_id]
 
             if state.request_id in self.current_batch:
                 self.remove_request_from_batch(state.request_id)
@@ -191,6 +191,9 @@ class GenerationLoopWorker(EngineBase):
 
         for state in list(self.current_batch.values()):
             if state.is_finished:
+                for gen_seq in state.generation_sequences:
+                    del self.sequence_map[gen_seq.seq_id]
+
                 self.remove_request_from_batch(state.request_id)
 
                 duration = time.time() - state.arrival_timestamp

--- a/serve/mlc_serve/engine/sync_engine.py
+++ b/serve/mlc_serve/engine/sync_engine.py
@@ -18,7 +18,6 @@ from .base import (
 )
 from .engine_common import (
     should_stop_by_length,
-    should_stop_seq_by_length,
     get_new_request_state,
     get_requests_to_process,
     update_sequence,
@@ -203,7 +202,8 @@ class SynchronousInferenceEngine(InferenceEngine, EngineBase):
 
             if gen_seq.is_finished:
                 finish_reason = FinishReason.Stop
-            if should_stop_seq_by_length(
+
+            if should_stop_by_length(
                 gen_seq,
                 state.prompt_len,
                 self.max_context_length,

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -109,7 +109,7 @@ def _test(args: argparse.Namespace):
                 assert len(res.sequences) == num_sequences, res
 
             for i, seq in enumerate(res.sequences):
-                if not seq.is_finished:
+                if seq.delta:
                     generated[int(res.request_id)][i] += seq.delta
 
     if args.long_prompt:

--- a/serve/tests/unittest/test_engine_with_samplers.py
+++ b/serve/tests/unittest/test_engine_with_samplers.py
@@ -205,7 +205,9 @@ def _test_stop(
             assert len(res.sequences) == 1
             seq = res.sequences[0]
             req_id = int(res.request_id)
-            generated[int(res.request_id)] += seq.delta
+
+            if seq.delta:
+                generated[int(res.request_id)] += seq.delta
 
             if seq.is_finished:
                 assert seq.finish_reason == FinishReason.Stop, f"{seq.finish_reason.name}"
@@ -214,7 +216,6 @@ def _test_stop(
                 # stop token should appear only once in the gen text.
                 found = sum([gen_txt.count(str_stop) for str_stop in requests[req_id].stopping_criteria.stop_sequences])
                 assert found == 1, f"{gen_txt!r}, matches: {found}"
-
 
     if use_staging_engine:
         engine.stop()


### PR DESCRIPTION
Depends on https://github.com/octoml/mlc-llm/pull/122

Fix four issues:

* `FinishReason.Stop` is not sent for termination due to an EOS token
* After all sequences in a request finishes, we return n empty sequences with the same finish reason. This is clearly incorrect since some of the sequences might have stopped earlier than those that finish with a length limit.
* Stopping check should be applied per sequence, not per request. 
* There is no reason to send a finish reason with empty delta. After this PR, a finish reason is delivered as soon as we detect termination.