### PR TITLE
Fix logit_bias index and value

### DIFF
--- a/serve/mlc_serve/engine/sampling_params.py
+++ b/serve/mlc_serve/engine/sampling_params.py
@@ -55,8 +55,9 @@ class SamplingParams:
 
     def __post_init__(self):
         self.appeared_tokens_freq = {}
-        self.logit_bias_index = list(self.logit_bias.keys())
-        self.logit_bias_value = list(self.logit_bias.values())
+        if self.logit_bias:
+            self.logit_bias_index = list(self.logit_bias.keys())
+            self.logit_bias_value = list(self.logit_bias.values())
         self._verify_args()
         if self.temperature < _SAMPLING_EPS:
             # Zero temperature means greedy sampling.


### PR DESCRIPTION
This PR fixes the `SamplingParams.logit_bias_index` and `SamplingParams.logit_bias_value` if `SamplingParams.logit_bias` is `None`.