### PR TITLE
Fix length discrepancy for decode after cache eviction

### DIFF
--- a/serve/mlc_serve/engine/engine_common.py
+++ b/serve/mlc_serve/engine/engine_common.py
@@ -193,7 +193,7 @@ def get_requests_to_process(
                 requests.append(
                     PrefillRequest(
                         request_id=state.request_id,
-                        token_ids=state.prompt_token_ids,
+                        token_ids=state.prompt_token_ids + state.generation_sequences[0].generated_token_ids,
                         num_sequence=state.num_sequences,
                         sampling_params=state.sampling_params,
                     )
@@ -352,6 +352,7 @@ class EngineBase:
                 continue
 
             self.remove_request_from_batch(request_to_remove.request_id)
+            request_to_remove.generation_sequences[0].next_start_position = 0
             self.queue.appendleft(request_to_remove)
 
             LOG.debug(


### PR DESCRIPTION
The NaN problem appeared due to 2 reasons
1. When we return request back after cache eviction we have to execute "prefill", at the same time the criteria if we need to do this is comparing of `GenerationSequence.next_start_position`  to zero that perfectly work for original requests, but after code eviction we have some fields initialized. Finally we allocate new blocks in kv-cache for returned tokens, but have not initialized them
2. When we have not executed "prefill" but want to execute decode, we have discrepancy between kv cache states which weas initialized as prefill on the full size of prompt+already decoded part and length of the sequence passed into decode
I.e. 
size of the prompt = prompt_size
size of already decode tokens = decoded_size
a. We are allocating prompt_size + decoded_size in the CacheManager.set_size for prefill
b. since we have not execute "prefill", see 1st bullet, We are starting to prepare data for decode in `_prepare_inputs()` and its logic assumes to fill `positions` and `seq_len` basing on the current len `seq_len = prompt_lens[i] + len(token_ids)` while kv_cache slot for the latest token by fact was taken into account during calculating data for prefill already. And we have one more slot allocated for such situation.
We can add assert somewhere at [this place](https://github.com/octoml/mlc-llm/blob/batch-serving/serve/mlc_serve/model/paged_cache_model.py#L239) verifying `if positions[-1] % 16 == slot_mapping[-1] % 16` but asserts are not good for production, need to add more clever error handling?
