### PR TITLE
Reraise cancellation error as expected by asyncio

### DIFF
--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -87,6 +87,7 @@ class AsyncEngineConnector:
             LOG.info("AsyncEngineConnector.generate iterator cancelled.", request_id=request.request_id)
             await asyncio.shield(asyncio.to_thread(self.engine.cancel, request.request_id))
             LOG.info("AsyncEngineConnector.generate request sucessfully cancelled.", request_id=request.request_id)
+            raise
         finally:
             LOG.info("AsyncEngineConnector.generate removing request from result queue.", request_id=request.request_id)
             self.result_queues.pop(request.request_id, None)


### PR DESCRIPTION
Doesn't seem to affect cancellation one way or the other by inspecting the logs, but this is the correct behavior as specified by asyncio docs.

And if we actually DON'T want to re-raise here, then we should be calling `uncancel`.