### PR TITLE
Fix trying to delete a dict element twice

### DIFF
--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -158,7 +158,9 @@ class GenerationLoopWorker(EngineBase):
                         error=err,
                     )
                 )
-                del self.sequence_map[gen_seq.seq_id]
+
+                if gen_seq.seq_id in self.sequence_map:
+                    del self.sequence_map[gen_seq.seq_id]
 
             if state.request_id in self.current_batch:
                 self.remove_request_from_batch(state.request_id)


### PR DESCRIPTION
When a request has been "finished" before `create_aborted_requests` is called on it for whatever reason, we end up trying to delete a dict element twice. In such case, the dict element is deleted at
https://github.com/masahi/mlc-llm/blob/39c005b2cd97c7bc8876c00a750b1e1a88bfa2eb/serve/mlc_serve/engine/staging_engine_worker.py#L195-L197