### PR TITLE
Clean up in cancellations and name tasks for easier debugging

### DIFF
--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -97,22 +97,27 @@ class AsyncEngineConnector:
             self.result_queues.pop(request.request_id, None)
 
     async def _get_queue_item_until_stopped(self, queue: ResultQueue) -> RequestOutput:
-        get_queue_task = asyncio.create_task(queue.get(), name="get_queue_task")
-        wait_shutdown_task = asyncio.create_task(self.shutdown_event.wait(), name="wait_shutdown_task")
+        try:
+            get_queue_task = asyncio.create_task(queue.get(), name="get_queue_task")
+            wait_shutdown_task = asyncio.create_task(self.shutdown_event.wait(), name="wait_shutdown_task")
 
-        await asyncio.wait(
-            (get_queue_task, wait_shutdown_task),
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+            await asyncio.wait(
+                (get_queue_task, wait_shutdown_task),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
-        if wait_shutdown_task.done():
-            if self.engine_loop_exception is not None:
-                raise EngineException("raised while handling previous engine loop exception") from self.engine_loop_exception
-            else:
-                raise EngineException("stopped with no exception")
+            if wait_shutdown_task.done():
+                if self.engine_loop_exception is not None:
+                    raise EngineException("raised while handling previous engine loop exception") from self.engine_loop_exception
+                else:
+                    raise EngineException("stopped with no exception")
 
-        wait_shutdown_task.cancel()
-        return get_queue_task.result()
+            wait_shutdown_task.cancel()
+            return get_queue_task.result()
+        except asyncio.CancelledError:
+            wait_shutdown_task.cancel()
+            get_queue_task.cancel()
+            raise
 
     async def _add_request(self, request: Request) -> ResultQueue:
         if self.engine_loop_task is None:

--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -97,8 +97,8 @@ class AsyncEngineConnector:
             self.result_queues.pop(request.request_id, None)
 
     async def _get_queue_item_until_stopped(self, queue: ResultQueue) -> RequestOutput:
-        get_queue_task = asyncio.create_task(queue.get())
-        wait_shutdown_task = asyncio.create_task(self.shutdown_event.wait())
+        get_queue_task = asyncio.create_task(queue.get(), name="get_queue_task")
+        wait_shutdown_task = asyncio.create_task(self.shutdown_event.wait(), name="wait_shutdown_task")
 
         await asyncio.wait(
             (get_queue_task, wait_shutdown_task),


### PR DESCRIPTION
This was found to eliminate the "Task destroyed but still active" errors under user request cancellations.