### PR TITLE
Latency Benchmark Script for User-side Metric

### DIFF
--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -53,7 +53,7 @@ def main(args: argparse.Namespace):
 
     print(
         f"User side metrics\n"
-        f"* number of input tokens: {args.num_input_tokens}, number of output tokens: {args.num_output_tokens}"
+        f"* number of input tokens: {args.num_input_tokens}, number of output tokens: {args.num_output_tokens}\n"
         f"* Time To First Token (TTFT): {ttft*1000:.3f} ms\n"
         f"* Inter-Subsequent-Token-Latency (ISTL): {itl*1000:.3f} ms ({1/itl:.3f} tok/s)\n"
         f"* End-to-end latency: {e2e:.3f} s\n"

--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -52,9 +52,8 @@ def main(args: argparse.Namespace):
     e2e = np.sum(latencies)
 
     print(
-        f"number of input tokens: {args.num_input_tokens}, number of output tokens: {args.num_output_tokens}"
-    )
-    print(
+        f"User side metrics\n"
+        f"* number of input tokens: {args.num_input_tokens}, number of output tokens: {args.num_output_tokens}"
         f"* Time To First Token (TTFT): {ttft*1000:.3f} ms\n"
         f"* Inter-Subsequent-Token-Latency (ISTL): {itl*1000:.3f} ms ({1/itl:.3f} tok/s)\n"
         f"* End-to-end latency: {e2e:.3f} s\n"

--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -10,22 +10,19 @@ from mlc_serve.engine import (
 from mlc_serve.utils import (
     get_default_mlc_serve_argparser,
     postproc_mlc_serve_args,
-    create_engine_and_tokenizer_module,
+    create_mlc_engine,
 )
-
-# /opt/bin/cuda-reserve.py --num-gpu 2 nsys profile --stats true -o mlc-serve-mixtral-sampling-before -w true -t cuda,nvtx,osrt,cudnn,cublas python3 serve/benchmarks/benchmark_throughput.py --local-id Mixtral-8x7B-Instruct-v0.1-q0f16-presharded-2gpu/  --max-num-sequences 1 --max-input-len 32000 --num-prompts 1 --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json
-
 
 def main(args: argparse.Namespace):
     print(args)
 
-    engine = create_engine_and_tokenizer_module(args)[0]
+    engine = create_mlc_engine(args)
     engine.add(
         [
             Request(
                 request_id="0",
                 messages=None,
-                sampling_params=SamplingParams(temperature=0.0),
+                sampling_params=SamplingParams(temperature=args.temperature),
                 stopping_criteria=StoppingCriteria(
                     max_tokens=args.num_output_tokens, stop_sequences=None
                 ),
@@ -64,6 +61,9 @@ if __name__ == "__main__":
     parser = get_default_mlc_serve_argparser(description="Benchmark the throughput.")
     parser.add_argument("--num-input-tokens", type=int, default=128)
     parser.add_argument("--num-output-tokens", type=int, default=128)
+    parser.add_argument(
+        "--temperature", type=float, default=0.5, help="Temparature. By default, random sampling has used."
+    )
     args = parser.parse_args()
     args = postproc_mlc_serve_args(args)
 

--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -1,4 +1,4 @@
-"""Benchmark offline user metric."""
+"""Benchmark latency offline."""
 import argparse
 import time, numpy as np
 from mlc_serve.engine import (

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -71,7 +71,7 @@ def run_mii(requests: List[Tuple[str, int, int]], args) -> float:
     start = time.perf_counter()
     engine(
         prompts,
-        max_new_tokens=args.max_output_tokens,
+        max_new_tokens=args.num_output_tokens,
         ignore_eos=SAMPLER_SETTING["ignore_eos"],
         # mii does not support temperature of zero.
         temperature=(0.000001 if random.random() <= args.greedy_sampling_ratio else 1.0),
@@ -103,7 +103,7 @@ def run_vllm(requests: List[Tuple[str, int, int]], args) -> float:
                 use_beam_search=False,
                 temperature=(0.0 if random.random() <= args.greedy_sampling_ratio else 1.0),
                 ignore_eos=SAMPLER_SETTING["ignore_eos"],
-                max_tokens=args.max_output_tokens,
+                max_tokens=args.num_output_tokens,
             ),
         )
 
@@ -124,7 +124,7 @@ def run_mlc(engine, requests, args) -> float:
                         temperature=(0.0 if random.random() <= args.greedy_sampling_ratio else 1.0)
                     ),
                     stopping_criteria=StoppingCriteria(
-                        max_tokens=args.max_output_tokens, stop_sequences=None
+                        max_tokens=args.num_output_tokens, stop_sequences=None
                     ),
                     num_sequences=args.num_sequences_to_sample,
                     debug_options=DebugOptions(
@@ -177,7 +177,7 @@ def main(args: argparse.Namespace):
             elapsed_time = run_vllm(requests, args)
 
     total_num_tokens = sum(
-        prompt_len + args.max_output_tokens * args.num_sequences_to_sample
+        prompt_len + args.num_output_tokens * args.num_sequences_to_sample
         for _, prompt_len, _ in requests
     )
     req_per_sec = len(requests) / elapsed_time
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         "--greedy-sampling-ratio", type=float, default=0.5, help="Ratio of greedy sampling in the requests."
     )
     parser.add_argument(
-        "--max-output-tokens",
+        "--num-output-tokens",
         type=int,
         default=128,
         help="Maximum number of generation tokens.",

--- a/serve/benchmarks/benchmark_user_metric.py
+++ b/serve/benchmarks/benchmark_user_metric.py
@@ -1,0 +1,71 @@
+"""Benchmark offline user metric."""
+import argparse
+import time, numpy as np
+from mlc_serve.engine import (
+    DebugOptions,
+    Request,
+    SamplingParams,
+    StoppingCriteria,
+)
+from mlc_serve.utils import (
+    get_default_mlc_serve_argparser,
+    postproc_mlc_serve_args,
+    create_engine_and_tokenizer_module,
+)
+
+# /opt/bin/cuda-reserve.py --num-gpu 2 nsys profile --stats true -o mlc-serve-mixtral-sampling-before -w true -t cuda,nvtx,osrt,cudnn,cublas python3 serve/benchmarks/benchmark_throughput.py --local-id Mixtral-8x7B-Instruct-v0.1-q0f16-presharded-2gpu/  --max-num-sequences 1 --max-input-len 32000 --num-prompts 1 --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json
+
+
+def main(args: argparse.Namespace):
+    print(args)
+
+    engine = create_engine_and_tokenizer_module(args)[0]
+    engine.add(
+        [
+            Request(
+                request_id="0",
+                messages=None,
+                sampling_params=SamplingParams(temperature=0.0),
+                stopping_criteria=StoppingCriteria(
+                    max_tokens=args.num_output_tokens, stop_sequences=None
+                ),
+                debug_options=DebugOptions(
+                    ignore_eos=True, prompt_token_ids=[3] * args.num_input_tokens
+                ),
+                num_sequences=args.num_sequences_to_sample,
+            )
+        ]
+    )
+
+    latencies = []
+    while engine.has_pending_requests():
+        t0 = time.perf_counter()
+        engine.step()
+        t1 = time.perf_counter()
+        latencies.append(t1 - t0)
+
+    if args.use_staging_engine:
+        engine.stop()
+
+    ttft = latencies[0]  # time to first token
+    itl = np.mean(latencies[1:])  # inter-token latency for subsequent tokens
+    e2e = np.sum(latencies)
+
+    print(
+        f"number of input tokens: {args.num_input_tokens}, number of output tokens: {args.num_output_tokens}"
+    )
+    print(
+        f"* Time To First Token (TTFT): {ttft*1000:.3f} ms\n"
+        f"* Inter-Subsequent-Token-Latency (ISTL): {itl*1000:.3f} ms ({1/itl:.3f} tok/s)\n"
+        f"* End-to-end latency: {e2e:.3f} s\n"
+    )
+
+
+if __name__ == "__main__":
+    parser = get_default_mlc_serve_argparser(description="Benchmark the throughput.")
+    parser.add_argument("--num-input-tokens", type=int, default=128)
+    parser.add_argument("--num-output-tokens", type=int, default=128)
+    args = parser.parse_args()
+    args = postproc_mlc_serve_args(args)
+
+    main(args)

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -57,7 +57,7 @@ def create_mlc_engine(args: argparse.Namespace):
         }
     )
     
-    # TODO(@team): There is a type mismatch in the definition. Fix this when have time. 
+    # TODO(@team): There is a type mismatch in the definition. Let's fix this when have time. 
     if args.use_staging_engine:
         engine = StagingInferenceEngine( # type: ignore
             tokenizer_module=HfTokenizerModule(args.model_artifact_path),

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -56,11 +56,11 @@ def create_mlc_engine(args: argparse.Namespace):
             "max_decode_steps": args.max_decode_steps,
         }
     )
-
+    # type: off
     if args.use_staging_engine:
         engine = StagingInferenceEngine(
             tokenizer_module=HfTokenizerModule(args.model_artifact_path),
-            model_module_loader=PagedCacheModelModule,
+            model_module_loader=PagedCacheModelModule, 
             model_module_loader_kwargs={
                 "model_artifact_path": args.model_artifact_path,
                 "engine_config": engine_config,
@@ -68,12 +68,12 @@ def create_mlc_engine(args: argparse.Namespace):
         )
         engine.start()
     else:
-        engine = SynchronousInferenceEngine(
-            PagedCacheModelModule(
+        engine = SynchronousInferenceEngine( 
+            PagedCacheModelModule( 
                 model_artifact_path=args.model_artifact_path,
                 engine_config=engine_config,
             )
         )
-
+    # type: on
     return engine
 

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -57,6 +57,7 @@ def create_mlc_engine(args: argparse.Namespace):
         }
     )
     
+    # TODO(@team): There is a type mismatch in the definition. Fix this when have time. 
     if args.use_staging_engine:
         engine = StagingInferenceEngine( # type: ignore
             tokenizer_module=HfTokenizerModule(args.model_artifact_path),

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -56,11 +56,11 @@ def create_mlc_engine(args: argparse.Namespace):
             "max_decode_steps": args.max_decode_steps,
         }
     )
-    # type: off
+    
     if args.use_staging_engine:
-        engine = StagingInferenceEngine(
+        engine = StagingInferenceEngine( # type: ignore
             tokenizer_module=HfTokenizerModule(args.model_artifact_path),
-            model_module_loader=PagedCacheModelModule, 
+            model_module_loader=PagedCacheModelModule, # type: ignore
             model_module_loader_kwargs={
                 "model_artifact_path": args.model_artifact_path,
                 "engine_config": engine_config,
@@ -68,12 +68,11 @@ def create_mlc_engine(args: argparse.Namespace):
         )
         engine.start()
     else:
-        engine = SynchronousInferenceEngine( 
-            PagedCacheModelModule( 
+        engine = SynchronousInferenceEngine( # type: ignore
+            PagedCacheModelModule( # type: ignore
                 model_artifact_path=args.model_artifact_path,
                 engine_config=engine_config,
             )
         )
-    # type: on
     return engine
 

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -1,10 +1,16 @@
 """Utility functions for mlc-serve"""
-from mlc_serve.logging_utils import configure_logging
+
 from pathlib import Path
 import os
 import torch
 import random
 import argparse
+
+from mlc_serve.engine import get_engine_config
+from mlc_serve.logging_utils import configure_logging
+from mlc_serve.engine.staging_engine import StagingInferenceEngine
+from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
+from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
 
 
 def get_default_mlc_serve_argparser(description="", allow_override=False):
@@ -38,3 +44,36 @@ def postproc_mlc_serve_args(args):
     torch.cuda.manual_seed(args.seed)
     random.seed(args.seed)
     return args
+
+
+def create_mlc_engine(args: argparse.Namespace):
+    engine_config = get_engine_config(
+        {
+            "use_staging_engine": args.use_staging_engine,
+            "max_num_sequences": args.max_num_sequences,
+            "max_input_len": args.max_input_len,
+            "min_decode_steps": args.min_decode_steps,
+            "max_decode_steps": args.max_decode_steps,
+        }
+    )
+
+    if args.use_staging_engine:
+        engine = StagingInferenceEngine(
+            tokenizer_module=HfTokenizerModule(args.model_artifact_path),
+            model_module_loader=PagedCacheModelModule,
+            model_module_loader_kwargs={
+                "model_artifact_path": args.model_artifact_path,
+                "engine_config": engine_config,
+            },
+        )
+        engine.start()
+    else:
+        engine = SynchronousInferenceEngine(
+            PagedCacheModelModule(
+                model_artifact_path=args.model_artifact_path,
+                engine_config=engine_config,
+            )
+        )
+
+    return engine
+


### PR DESCRIPTION
Example usage
```
python3 serve/benchmarks/benchmark_latency.py --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu  --max-num-sequences 1 --max-input-len 32000
```

```
# Result on Mixtral fp16 on 2xH100

User side metrics
* number of input tokens: 128, number of output tokens: 128
* Time To First Token (TTFT): 96.519 ms
* Inter-Subsequent-Token-Latency (ISTL): 13.745 ms (72.753 tok/s)
* End-to-end latency: 1.842 s
```

This PR needs to be updated once https://github.com/octoml/mlc-llm/pull/117 gets in. 