### PR TITLE
Benchmark with More Sampling Settings (e.g., Penalties, Logit bias, top-p, top-k)

### DIFF
--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -26,12 +26,14 @@ def main(args: argparse.Namespace):
                 messages=None,  # Provide prompt as `DebugOption` to bypass the conv template
                 sampling_params=SamplingParams(
                     temperature=args.temperature,
-                    top_p=1
-                    if args.temperature == 0.0
-                    else args.sampling_setting["top_p"],
-                    top_k=-1
-                    if args.temperature == 0.0
-                    else args.sampling_setting["top_p"],
+                    top_p=(
+                        1 if args.temperature == 0.0 else args.sampling_setting["top_p"]
+                    ),
+                    top_k=(
+                        -1
+                        if args.temperature == 0.0
+                        else args.sampling_setting["top_k"]
+                    ),
                     repetition_penalty=args.sampling_setting["repetition_penalty"],
                     frequency_penalty=args.sampling_setting["frequency_penalty"],
                     presence_penalty=args.sampling_setting["presence_penalty"],
@@ -58,6 +60,7 @@ def main(args: argparse.Namespace):
     if args.use_staging_engine:
         engine.stop()
 
+    assert len(latencies) == args.num_output_tokens
     ttft = latencies[0]  # time to first token
     itl = np.mean(latencies[1:])  # inter-token latency for subsequent tokens
     e2e = np.sum(latencies)

--- a/serve/benchmarks/benchmark_latency.py
+++ b/serve/benchmarks/benchmark_latency.py
@@ -12,6 +12,8 @@ from mlc_serve.utils import (
     postproc_mlc_serve_args,
     create_mlc_engine,
 )
+from utils import add_sampling_flags, postproc_sampling_args
+
 
 def main(args: argparse.Namespace):
     print(args)
@@ -21,8 +23,20 @@ def main(args: argparse.Namespace):
         [
             Request(
                 request_id="0",
-                messages=None,
-                sampling_params=SamplingParams(temperature=args.temperature),
+                messages=None,  # Provide prompt as `DebugOption` to bypass the conv template
+                sampling_params=SamplingParams(
+                    temperature=args.temperature,
+                    top_p=1
+                    if args.temperature == 0.0
+                    else args.sampling_setting["top_p"],
+                    top_k=-1
+                    if args.temperature == 0.0
+                    else args.sampling_setting["top_p"],
+                    repetition_penalty=args.sampling_setting["repetition_penalty"],
+                    frequency_penalty=args.sampling_setting["frequency_penalty"],
+                    presence_penalty=args.sampling_setting["presence_penalty"],
+                    logit_bias=args.sampling_setting["logit_bias"],
+                ),
                 stopping_criteria=StoppingCriteria(
                     max_tokens=args.num_output_tokens, stop_sequences=None
                 ),
@@ -62,9 +76,14 @@ if __name__ == "__main__":
     parser.add_argument("--num-input-tokens", type=int, default=128)
     parser.add_argument("--num-output-tokens", type=int, default=128)
     parser.add_argument(
-        "--temperature", type=float, default=0.5, help="Temparature. By default, random sampling has used."
+        "--temperature",
+        type=float,
+        default=0.5,
+        help="Temparature. By default, random sampling has used.",
     )
+    add_sampling_flags(parser)
     args = parser.parse_args()
-    args = postproc_mlc_serve_args(args)
+    postproc_mlc_serve_args(args)
+    postproc_sampling_args(args)
 
     main(args)

--- a/serve/benchmarks/benchmark_throughput.py
+++ b/serve/benchmarks/benchmark_throughput.py
@@ -6,7 +6,6 @@ from typing import List, Tuple
 import argparse
 import pandas as pd
 from mlc_serve.engine import (
-    ChatMessage,
     DebugOptions,
     Request,
     SamplingParams,
@@ -17,8 +16,8 @@ from mlc_serve.utils import (
     postproc_mlc_serve_args,
     create_mlc_engine,
 )
+from utils import add_sampling_flags, postproc_sampling_args
 
-SAMPLER_SETTING = {"ignore_eos": True}
 
 def sample_requests(
     dataset_path: str,
@@ -72,9 +71,11 @@ def run_mii(requests: List[Tuple[str, int, int]], args) -> float:
     engine(
         prompts,
         max_new_tokens=args.num_output_tokens,
-        ignore_eos=SAMPLER_SETTING["ignore_eos"],
+        ignore_eos=args.sampling_setting["ignore_eos"],
         # mii does not support temperature of zero.
-        temperature=(0.000001 if random.random() <= args.greedy_sampling_ratio else 1.0),
+        temperature=(
+            0.000001 if random.random() <= args.greedy_sampling_ratio else 0.7
+        ),
     )
     end = time.perf_counter()
     return end - start
@@ -95,14 +96,21 @@ def run_vllm(requests: List[Tuple[str, int, int]], args) -> float:
 
     # Add the requests to the engine.
     for prompt, _, _ in requests:
+        temp = 0.0 if random.random() <= args.greedy_sampling_ratio else 0.7
         llm._add_request(
             prompt=prompt,
             prompt_token_ids=None,
             sampling_params=SamplingParams(
                 n=args.num_sequences_to_sample,
                 use_beam_search=False,
-                temperature=(0.0 if random.random() <= args.greedy_sampling_ratio else 1.0),
-                ignore_eos=SAMPLER_SETTING["ignore_eos"],
+                temperature=temp,
+                top_p=1 if temp == 0.0 else args.sampling_setting["top_p"],
+                top_k=-1 if temp == 0.0 else args.sampling_setting["top_p"],
+                repetition_penalty=args.sampling_setting["repetition_penalty"],
+                frequency_penalty=args.sampling_setting["frequency_penalty"],
+                presence_penalty=args.sampling_setting["presence_penalty"],
+                # vllm does not support `logit bias`
+                ignore_eos=args.sampling_setting["ignore_eos"],
                 max_tokens=args.num_output_tokens,
             ),
         )
@@ -115,20 +123,27 @@ def run_vllm(requests: List[Tuple[str, int, int]], args) -> float:
 
 def run_mlc(engine, requests, args) -> float:
     for i, (prompt, _, _) in enumerate(requests):
+        temp = 0.0 if random.random() <= args.greedy_sampling_ratio else 0.7
         engine.add(
             [
                 Request(
                     request_id=str(i),
-                    messages=[ChatMessage(role="user", content=prompt)],
+                    messages=None,  # Provide prompt as `DebugOption` to bypass the conv template
                     sampling_params=SamplingParams(
-                        temperature=(0.0 if random.random() <= args.greedy_sampling_ratio else 1.0)
+                        temperature=temp,
+                        top_p=1 if temp == 0.0 else args.sampling_setting["top_p"],
+                        top_k=-1 if temp == 0.0 else args.sampling_setting["top_p"],
+                        repetition_penalty=args.sampling_setting["repetition_penalty"],
+                        frequency_penalty=args.sampling_setting["frequency_penalty"],
+                        presence_penalty=args.sampling_setting["presence_penalty"],
+                        logit_bias=args.sampling_setting["logit_bias"],
                     ),
                     stopping_criteria=StoppingCriteria(
                         max_tokens=args.num_output_tokens, stop_sequences=None
                     ),
                     num_sequences=args.num_sequences_to_sample,
                     debug_options=DebugOptions(
-                        ignore_eos=SAMPLER_SETTING["ignore_eos"], prompt=prompt
+                        ignore_eos=args.sampling_setting["ignore_eos"], prompt=prompt
                     ),
                 )
             ]
@@ -200,7 +215,9 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    parser = get_default_mlc_serve_argparser(description="Benchmark the throughput.", allow_override=True)
+    parser = get_default_mlc_serve_argparser(
+        description="Benchmark the throughput.", allow_override=True
+    )
     parser.add_argument(
         "--backend", type=str, default="mlc-serve", choices=["mlc-serve", "vllm", "mii"]
     )
@@ -211,7 +228,10 @@ if __name__ == "__main__":
         "--num-prompts", type=int, default=1000, help="Number of prompts to process."
     )
     parser.add_argument(
-        "--greedy-sampling-ratio", type=float, default=0.5, help="Ratio of greedy sampling in the requests."
+        "--greedy-sampling-ratio",
+        type=float,
+        default=0.5,
+        help="Ratio of greedy sampling in the requests.",
     )
     parser.add_argument(
         "--num-output-tokens",
@@ -257,10 +277,12 @@ if __name__ == "__main__":
         "for FP32 and FP16 models, and BF16 precision "
         "for BF16 models.",
     )
-
+    add_sampling_flags(parser)
     args = parser.parse_args()
     if args.backend == "mlc-serve":
-        args = postproc_mlc_serve_args(args)
+        postproc_mlc_serve_args(args)
 
-    assert args.greedy_sampling_ratio >= 0.0 and  args.greedy_sampling_ratio <= 1.0
+    assert args.greedy_sampling_ratio >= 0.0 and args.greedy_sampling_ratio <= 1.0
+    postproc_sampling_args(args)
+
     main(args)

--- a/serve/benchmarks/utils.py
+++ b/serve/benchmarks/utils.py
@@ -1,0 +1,53 @@
+"""Utils for benchmark scripts"""
+
+
+def add_sampling_flags(parser):
+    parser.add_argument(
+        "--apply-penalties",
+        action="store_true",
+        help="Apply presence/repetiton/frequency penalties.",
+    )
+    parser.add_argument(
+        "--apply-logit-bias",
+        action="store_true",
+        help="Apply logit bias.",
+    )
+    parser.add_argument(
+        "--apply-top-p-top-k",
+        action="store_true",
+        help="Apply top-p and top-k.",
+    )
+    parser.add_argument(
+        "--apply-all-sampling-params",
+        action="store_true",
+        help="Apply all penalties, logit bias, top-p and top-k.",
+    )
+
+
+def postproc_sampling_args(args):
+    args.sampling_setting = {
+        "ignore_eos": True,
+        "logit_bias": None,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "repetition_penalty": 1.0,
+        "top_p": 1.0,
+        "top_k": -1,
+    }
+
+    if args.apply_all_sampling_params:
+        args.apply_penalties = True
+        args.apply_logit_bias = True
+        args.apply_top_p_top_k = True
+
+    if args.apply_penalties:
+        args.sampling_setting["presence_penalty"] = 0.7
+        args.sampling_setting["frequency_penalty"] = 0.7
+        args.sampling_setting["repetition_penalty"] = 0.7
+
+    if args.apply_logit_bias:
+        args.sampling_setting["logit_bias"] = {1: -1, 3: 1, 2: 2}
+
+    if args.apply_top_p_top_k:
+        args.sampling_setting["top_k"] = 2
+        args.sampling_setting["top_p"] = 0.7

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -15,7 +15,9 @@ from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModel
 
 def get_default_mlc_serve_argparser(description="", allow_override=False):
     if allow_override:
-        parser = argparse.ArgumentParser(description=description, conflict_handler="resolve")
+        parser = argparse.ArgumentParser(
+            description=description, conflict_handler="resolve"
+        )
     else:
         parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--local-id", type=str, required=True)
@@ -43,7 +45,6 @@ def postproc_mlc_serve_args(args):
     torch.manual_seed(args.seed)
     torch.cuda.manual_seed(args.seed)
     random.seed(args.seed)
-    return args
 
 
 def create_mlc_engine(args: argparse.Namespace):
@@ -56,12 +57,12 @@ def create_mlc_engine(args: argparse.Namespace):
             "max_decode_steps": args.max_decode_steps,
         }
     )
-    
-    # TODO(@team): There is a type mismatch in the definition. Let's fix this when have time. 
+
+    # TODO(@team): There is a type mismatch in the definition. Let's fix this when have time.
     if args.use_staging_engine:
-        engine = StagingInferenceEngine( # type: ignore
+        engine = StagingInferenceEngine(  # type: ignore
             tokenizer_module=HfTokenizerModule(args.model_artifact_path),
-            model_module_loader=PagedCacheModelModule, # type: ignore
+            model_module_loader=PagedCacheModelModule,  # type: ignore
             model_module_loader_kwargs={
                 "model_artifact_path": args.model_artifact_path,
                 "engine_config": engine_config,
@@ -69,11 +70,10 @@ def create_mlc_engine(args: argparse.Namespace):
         )
         engine.start()
     else:
-        engine = SynchronousInferenceEngine( # type: ignore
-            PagedCacheModelModule( # type: ignore
+        engine = SynchronousInferenceEngine(  # type: ignore
+            PagedCacheModelModule(  # type: ignore
                 model_artifact_path=args.model_artifact_path,
                 engine_config=engine_config,
             )
         )
     return engine
-

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     parser.add_argument("--use-random-sampling", action="store_true")
     parser.add_argument("--max-output-len", type=int, default=20)
     args = parser.parse_args()
-    args = postproc_mlc_serve_args(args)
+    postproc_mlc_serve_args(args)
 
     if args.long_prompt:
         args.max_input_len = 10000

--- a/serve/tests/unittest/test_engine_with_samplers.py
+++ b/serve/tests/unittest/test_engine_with_samplers.py
@@ -352,7 +352,7 @@ def test_penalty(
 if __name__ == "__main__":
     parser = get_default_mlc_serve_argparser("test engine with samplers")
     args = parser.parse_args()
-    args = postproc_mlc_serve_args(args)
+    postproc_mlc_serve_args(args)
 
     _test_max_tokens(args.model_artifact_path, use_staging_engine=True)
     _test_max_tokens(args.model_artifact_path, use_staging_engine=False)


### PR DESCRIPTION
Added flags to benchmark with more sampling settings
```
--apply-penalties
--apply-logit-bias
--apply-top-p-top-k
--apply-all-sampling-params: This will configure all three above.
```

Benchmark with Mixtral fp16 on 2xH100: 
1. Latency
```
# Greedy: python3 serve/benchmarks/benchmark_latency.py --temperature 0 --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu  --max-num-sequences 1 --max-input-len 32000
User side metrics
* number of input tokens: 128, number of output tokens: 128
* Time To First Token (TTFT): 93.692 ms
* Inter-Subsequent-Token-Latency (ISTL): 14.073 ms (71.060 tok/s)
* End-to-end latency: 1.881 s

# Random w/o any penalties, logit-bias, top-p/top-k: python3 serve/benchmarks/benchmark_latency.py --temperature 0.5 --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu  --max-num-sequences 1 --max-input-len 32000 
User side metrics
* number of input tokens: 128, number of output tokens: 128
* Time To First Token (TTFT): 155.637 ms
* Inter-Subsequent-Token-Latency (ISTL): 14.227 ms (70.290 tok/s)
* End-to-end latency: 1.962 s

# Random w/ penalties, logit-bias, top-p/top-k: python3 serve/benchmarks/benchmark_latency.py --temperature 0.5 --apply-all-sampling-params --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu  --max-num-sequences 1 --max-input-len 32000 
User side metrics
* number of input tokens: 128, number of output tokens: 128
* Time To First Token (TTFT): 357.872 ms
* Inter-Subsequent-Token-Latency (ISTL): 15.033 ms (66.519 tok/s)
* End-to-end latency: 2.267 s
```

2. Throughput
```
# w/o penalties, logit-bias, top-p/top-k: python3 serve/benchmarks/benchmark_throughput.py --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000 --max-num-sequences 1 --max-input-len 32000
Engine Throughput: 22.67 requests/s, 8672.43 tokens/s

# w/ penalties, logit-bias, top-p/top-k: python3 serve/benchmarks/benchmark_throughput.py --apply-all-sampling-params --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000 --max-num-sequences 1 --max-input-len 32000 
Engine Throughput: 15.21 requests/s, 5818.80 tokens/s
```

This results show the extra overhead from such sampling computations. 