### PR TITLE
[Disco] Pass entrypoint to disco session after upstream changes

### DIFF
--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -146,7 +146,7 @@ def sample(
 
 
 def load_disco_module(artifact_path, lib_path, num_shards):
-    sess = di.ProcessSession(num_workers=num_shards)
+    sess = di.ProcessSession(num_workers=num_shards, entrypoint="tvm.exec.disco_worker")
     devices = range(num_shards)
     sess.init_ccl("nccl", *devices)
     module = sess.load_vm_module(lib_path)


### PR DESCRIPTION
This is needed if we use the rebased branch https://github.com/vinx13/tvm/tree/for-mlc-serve-jan9