### PR TITLE
Add new Relax function to the batched model for evaluating query tokens over multiple time steps in parallel 

### DIFF
--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -120,7 +120,7 @@ class SequenceGenerationResponse:
 @dataclass
 class EvalQueryRequest:
     request_id: int
-    past_token_ids: List[int]
+    num_past_tokens: int
     query_token_ids: List[int]
 
 
@@ -262,11 +262,11 @@ def _prepare_eval_queries(
     positions = []
     permute_map = []
 
-    query_offset = sum([len(request.past_token_ids) for request in requests])
+    query_offset = sum([request.num_past_tokens for request in requests])
     past_offset = 0
 
     for request in requests:
-        num_past_tokens = len(request.past_token_ids)
+        num_past_tokens = request.num_past_tokens
         num_queries = len(request.query_token_ids)
         query_lens.append(num_queries)
         request_id = request.request_id
@@ -521,8 +521,8 @@ def run(args):
 
     for request_id, query_token_len in zip(request_ids, query_token_lens):
         queries_to_eval = requests[request_id].token_ids[-query_token_len:]
-        past_tokens = requests[request_id].token_ids[:-query_token_len]
-        eval_query_requests.append(EvalQueryRequest(request_id, past_tokens, queries_to_eval))
+        num_past = len(requests[request_id].token_ids) - query_token_len
+        eval_query_requests.append(EvalQueryRequest(request_id, num_past, queries_to_eval))
 
     (
         input_ids,

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -117,6 +117,13 @@ class SequenceGenerationResponse:
     token_id: int
 
 
+@dataclass
+class EvalQueryRequest:
+    request_id: int
+    past_token_ids: List[int]
+    query_token_ids: List[int]
+
+
 def sample(logits):
     logits = torch.from_dlpack(logits)
     return torch.argmax(logits, -1).cpu().numpy()
@@ -238,6 +245,76 @@ def _prepare_inputs(
         slot_mapping,
         indices_within_window,
         block_tables,
+    )
+
+
+def _prepare_eval_queries(
+    requests: List[EvalQueryRequest],
+    all_slot_mappings,
+    sliding_window,
+    dev,
+):
+    seq_lens = []
+    query_lens = []
+    input_ids = []
+    slot_mapping = []
+    past_slot_mapping = []
+    positions = []
+    permute_map = []
+
+    query_offset = sum([len(request.past_token_ids) for request in requests])
+    past_offset = 0
+
+    for request in requests:
+        num_past_tokens = len(request.past_token_ids)
+        num_queries = len(request.query_token_ids)
+        query_lens.append(num_queries)
+        request_id = request.request_id
+        input_ids += request.query_token_ids
+
+        positions += [num_past_tokens + i for i in range(num_queries)]
+
+        if sliding_window:
+            seq_lens.append(min(num_past_tokens + num_queries, sliding_window))
+            # TODO: verify this
+            past_slot_mapping += all_slot_mappings[request_id][
+                : min(num_past_tokens, sliding_window)
+            ]
+            slot_mapping += all_slot_mappings[request_id][
+                min(num_past_tokens, sliding_window) : min(num_past_tokens, sliding_window)
+                + num_queries
+            ]
+        else:
+            seq_lens.append(num_past_tokens + num_queries)
+            past_slot_mapping += all_slot_mappings[request_id][:num_past_tokens]
+            slot_mapping += all_slot_mappings[request_id][
+                num_past_tokens : num_past_tokens + num_queries
+            ]
+
+        permute_map += list(range(past_offset, past_offset + num_past_tokens)) + list(
+            range(query_offset, query_offset + num_queries)
+        )
+
+        query_offset += num_queries
+        past_offset += num_past_tokens
+
+    input_ids = tvm.nd.array(np.array(input_ids, dtype="int32"), dev)
+    positions = tvm.nd.array(np.array(positions, dtype="int32"), dev)
+    seq_lens = tvm.nd.array(np.array(seq_lens, dtype="int32"), dev)
+    slot_mapping = tvm.nd.array(np.array(slot_mapping, dtype="int32"), dev)
+
+    query_lens = tvm.nd.array(np.array(query_lens, dtype="int32"), dev)
+    past_slot_mapping = tvm.nd.array(np.array(past_slot_mapping, dtype="int32"), dev)
+    permute_map = tvm.nd.array(np.array(permute_map, dtype="int32"), dev)
+
+    return (
+        input_ids,
+        positions,
+        seq_lens,
+        slot_mapping,
+        query_lens,
+        past_slot_mapping,
+        permute_map,
     )
 
 
@@ -442,6 +519,59 @@ def run(args):
 
     for p, g in zip(prompts, generated):
         print("Prompt = '{}', generated text = '{}'".format(p, g))
+
+    query_token_lens = [4, 3, 5, 2]
+
+    eval_query_requests = []
+
+    for request_id, query_token_len in zip(request_ids, query_token_lens):
+        queries_to_eval = requests[request_id].token_ids[-query_token_len:]
+        past_tokens = requests[request_id].token_ids[:-query_token_len]
+        eval_query_requests.append(EvalQueryRequest(request_id, past_tokens, queries_to_eval))
+
+    (
+        input_ids,
+        positions,
+        seq_lens,
+        slot_mapping,
+        query_lens,
+        past_slot_mapping,
+        permute_map,
+    ) = _prepare_eval_queries(
+        eval_query_requests,
+        cache.slot_mappings,
+        None,
+        model.dev,
+    )
+
+    logits = model.mod["evaluate_multi_query"](
+        input_ids,
+        positions,
+        seq_lens,
+        cache.cache,
+        slot_mapping,
+        query_lens,
+        past_slot_mapping,
+        permute_map,
+        model.params,
+    )[0].numpy()
+
+    assert logits.shape[0] == sum(query_token_lens)
+
+    logits_offset = 0
+
+    for request_id, query_token_len in zip(request_ids, query_token_lens):
+        for i in range(query_token_len - 1):
+            # requests[request_id].token_ids[-query_token_len:] are the "ground truth" tokens.
+            # Doing argmax over multi-timestep logits computed in parallel should yield the same
+            # tokens at the corresponding positions.
+            past_tokens = requests[request_id].token_ids[:-query_token_len]
+            assert (
+                np.argmax(logits[logits_offset + i])
+                == requests[request_id].token_ids[len(past_tokens) + i + 1]
+            )
+
+        logits_offset += query_token_len
 
 
 if __name__ == "__main__":

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -276,14 +276,9 @@ def _prepare_eval_queries(
 
         if sliding_window:
             seq_lens.append(min(num_past_tokens + num_queries, sliding_window))
-            # TODO: verify this
-            past_slot_mapping += all_slot_mappings[request_id][
-                : min(num_past_tokens, sliding_window)
-            ]
-            slot_mapping += all_slot_mappings[request_id][
-                min(num_past_tokens, sliding_window) : min(num_past_tokens, sliding_window)
-                + num_queries
-            ]
+            num_past = min(num_past_tokens, sliding_window)
+            past_slot_mapping += all_slot_mappings[request_id][num_past:]
+            slot_mapping += all_slot_mappings[request_id][num_past: num_past + num_queries]
         else:
             seq_lens.append(num_past_tokens + num_queries)
             past_slot_mapping += all_slot_mappings[request_id][:num_past_tokens]

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -274,17 +274,18 @@ def _prepare_eval_queries(
 
         positions += [num_past_tokens + i for i in range(num_queries)]
 
-        if sliding_window:
-            seq_lens.append(min(num_past_tokens + num_queries, sliding_window))
-            num_past = min(num_past_tokens, sliding_window)
-            past_slot_mapping += all_slot_mappings[request_id][:num_past]
-            slot_mapping += all_slot_mappings[request_id][num_past: num_past + num_queries]
+        if sliding_window and num_past_tokens + num_queries >= sliding_window:
+            seq_lens.append(sliding_window)
+            past_slot_mapping += all_slot_mappings[request_id][
+                num_past_tokens - (sliding_window - num_queries) : num_past_tokens
+            ]
         else:
             seq_lens.append(num_past_tokens + num_queries)
             past_slot_mapping += all_slot_mappings[request_id][:num_past_tokens]
-            slot_mapping += all_slot_mappings[request_id][
-                num_past_tokens : num_past_tokens + num_queries
-            ]
+
+        slot_mapping += all_slot_mappings[request_id][
+            num_past_tokens : num_past_tokens + num_queries
+        ]
 
         permute_map += list(range(past_offset, past_offset + num_past_tokens)) + list(
             range(query_offset, query_offset + num_queries)

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -277,7 +277,7 @@ def _prepare_eval_queries(
         if sliding_window:
             seq_lens.append(min(num_past_tokens + num_queries, sliding_window))
             num_past = min(num_past_tokens, sliding_window)
-            past_slot_mapping += all_slot_mappings[request_id][num_past:]
+            past_slot_mapping += all_slot_mappings[request_id][:num_past]
             slot_mapping += all_slot_mappings[request_id][num_past: num_past + num_queries]
         else:
             seq_lens.append(num_past_tokens + num_queries)

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -593,6 +593,7 @@ def mod_transform_before_build(
             # This is equivalent to prefill but without KV cache. It is used for
             # determining the number of paged cache blocks that can be allocated.
             model_names.append("evaluate")
+            model_names.append("evaluate_multi_query")
 
         if args.sep_embed:
             model_names = ["embed", "prefill_with_embed"] + model_names[1:]


### PR DESCRIPTION
In speculative decoding and restoring KV cache entries for evicted parallel-sampling requests, we need to be able to compute logits over multiple tokens (time steps) while utilizing the KV cache for the past tensors. This is a hybrid of `prefill` and `decode` functions, in that
* `prefill` can compute logits over multiple tokens but doesn't read from KV cache
* `decode` works on one token at a time.  

I'm introducing a new function, tentatively called `evaluate_multi_query`, for this purpose. `multi_query_decode` is also a good name.

The changes in `run_llama_batched_vllm.py` shows a new request type and how the new function is meant to be used. There is no change under `serve` yet since it is purely a model change. After we agree on the approach, I'll integrate this new function into the engine to complete my parallel-sampling work. @yelite needs this for speculative decoding.

There is no attention kernel that reads from KV cache and operates on multiple queries, except FlashInfer which has `BatchedPrefillWithKVCache`. But we can emulate the behavior of such kernel by materializing past KV tensors from the cache, concat them with the present tensors, and running the standard prefill attention. This is not efficient but its correctness is much easier to verify. Until we integrate FlashInfer or Flash attention adds paged KV cache support, we can use this emulation.

@sunggg @yelite @elvin-n