### PR TITLE
Remove max_input_len and max_num_sequences

### DIFF
--- a/serve/mlc_serve/engine/base.py
+++ b/serve/mlc_serve/engine/base.py
@@ -19,14 +19,7 @@ class MLCServeEngineConfig:
     # The maximum number of tokens in the batch.
     # TODO(@sunggg): figure out better defaults
     use_staging_engine: bool = True
-    # we don't generally expect users to set `max_num_batched_tokens` directly
-    # since it is less intuitive.
-    # instead, we expose `max_input_len` and `max_num_sequences`
-    # so that `max_num_batched_tokens` can be deduced by the following equation.
-    # -> `max_num_batched_tokens` = `max_input_len`*`max_num_sequences`
-    max_input_len: int = 512
-    max_num_sequences: int = 8
-    max_num_batched_tokens: int = -1
+    max_num_batched_tokens: int = 4096
     min_decode_steps: int = 32
     max_decode_steps: int = 48
     init_timeout: int = 120
@@ -48,22 +41,8 @@ def get_engine_config(dict_config):
     # since engine config is critical to the performance
     assert isinstance(engine_config.use_staging_engine, bool)
     assert isinstance(engine_config.max_num_batched_tokens, int)
-    assert isinstance(engine_config.max_input_len, int)
-    assert isinstance(engine_config.max_num_sequences, int)
     assert isinstance(engine_config.max_decode_steps, int)
     assert isinstance(engine_config.min_decode_steps, int)
-
-    # TODO(@sunggg): engine allows -1 for these params. figure out the behavior and enable checks properly
-    assert (
-        engine_config.max_num_batched_tokens == -1
-    ), "`max_num_batched_tokens` is not supposed to be configured directly. \
-            Use `max_num_sequences` and `max_input_len` instead."
-    assert engine_config.max_input_len > 0
-    assert engine_config.max_num_sequences > 0
-    engine_config.max_num_batched_tokens = (
-        engine_config.max_num_sequences * engine_config.max_input_len
-    )
-
     assert (engine_config.min_decode_steps > 0) and (engine_config.max_decode_steps > 0)
     assert engine_config.max_decode_steps > engine_config.min_decode_steps
 

--- a/serve/mlc_serve/model/dummy_model.py
+++ b/serve/mlc_serve/model/dummy_model.py
@@ -129,7 +129,7 @@ class DummyTextGenerator:
 
 
 class DummyModelModule:
-    def __init__(self, max_cached_tokens: int, max_input_len = 512, max_num_sequences = 8):
+    def __init__(self, max_cached_tokens: int, max_num_batched_tokens = 4096):
         self.tokenizer = DummyTokenizer()
         self.conversation_template = DummyConversationTemplate()
         self.text_generator = DummyTextGenerator()
@@ -141,8 +141,7 @@ class DummyModelModule:
             "max_decode_steps": 2,
             "min_decode_steps": 1,
             "use_staging_engine" : False,
-            "max_input_len": max_input_len,
-            "max_num_sequences": max_num_sequences
+            "max_num_batched_tokens": max_num_batched_tokens,
         })
 
 

--- a/serve/mlc_serve/model/tvm_model.py
+++ b/serve/mlc_serve/model/tvm_model.py
@@ -446,7 +446,7 @@ def init_tvm_model(
         LOG.info("Running memory profiling.")
         num_blocks = get_num_cache_blocks(
             model,
-            [engine_config.max_input_len] * engine_config.max_num_sequences,
+            [1] * engine_config.max_num_batched_tokens,
             model_artifact_config.num_hidden_layers,
             num_kv_heads,
             head_size,
@@ -462,7 +462,7 @@ def init_tvm_model(
             f" only {num_blocks} cache blocks can be allocated. The number of"
             f" available cache slots is {num_cache_slots}, not enough for"
             f" {engine_config.max_num_batched_tokens} tokens. Try reducing"
-            " --max_input_len or --max_num_sequences."
+            " --max_num_batched_tokens."
         )
 
     LOG.info(f"Using {num_blocks} cache blocks.")

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -23,7 +23,7 @@ def parse_args():
     # /opt/bin/cuda-reserve.py  --num-gpus 2 python -m mlc_serve --local-id vicuna-v1-7b-q0f16 --num-shards 2
     #
     # Profile the gpu memory usage, and use the maximum number of cache blocks possible:
-    # /opt/bin/cuda-reserve.py  --num-gpus 2 python -m mlc_serve --local-id vicuna-v1-7b-q0f16 --num-shards 2 --max-num-batched-tokens 2560 --max-input-len 256
+    # /opt/bin/cuda-reserve.py  --num-gpus 2 python -m mlc_serve --local-id vicuna-v1-7b-q0f16 --num-shards 2 --max-num-batched-tokens 2560
 
     # TODO(@sunggg): replace this with `utils.get_default_mlc_serve_argparser`
     # Since this will require the change in ollm side as well, revisit this after octocalm.
@@ -33,8 +33,7 @@ def parse_args():
     args.add_argument("--local-id", type=str, required=True)
     args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument("--use-staging-engine", action="store_true")
-    args.add_argument("--max-num-sequences", type=int, default=8)
-    args.add_argument("--max-input-len", type=int, default=512)
+    args.add_argument("--max-num-batched-tokens", type=int, default=4096)
     args.add_argument("--min-decode-steps", type=int, default=12)
     args.add_argument("--max-decode-steps", type=int, default=16)
     args.add_argument("--debug-logging", action="store_true")
@@ -61,8 +60,7 @@ def create_engine(
     engine_config = get_engine_config(
         {
             "use_staging_engine": args.use_staging_engine,
-            "max_num_sequences": args.max_num_sequences,
-            "max_input_len": args.max_input_len,
+            "max_num_batched_tokens": args.max_num_batched_tokens,
             "min_decode_steps": args.min_decode_steps,
             "max_decode_steps": args.max_decode_steps,
         }

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -23,9 +23,7 @@ def get_default_mlc_serve_argparser(description="", allow_override=False):
     parser.add_argument("--local-id", type=str, required=True)
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--use-sync-engine", action="store_true")
-    parser.add_argument("--max-num-sequences", type=int, default=8)
-    parser.add_argument("--num-sequences-to-sample", type=int, default=1)
-    parser.add_argument("--max-input-len", type=int, default=512)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=4096)
     parser.add_argument("--min-decode-steps", type=int, default=32)
     parser.add_argument("--max-decode-steps", type=int, default=56)
     parser.add_argument("--debug-logging", action="store_true")
@@ -51,8 +49,7 @@ def create_mlc_engine(args: argparse.Namespace):
     engine_config = get_engine_config(
         {
             "use_staging_engine": args.use_staging_engine,
-            "max_num_sequences": args.max_num_sequences,
-            "max_input_len": args.max_input_len,
+            "max_num_batched_tokens": args.max_num_batched_tokens,
             "min_decode_steps": args.min_decode_steps,
             "max_decode_steps": args.max_decode_steps,
         }

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -20,8 +20,7 @@ def _test(args: argparse.Namespace):
     engine_config = get_engine_config(
         {
             "use_staging_engine": args.use_staging_engine,
-            "max_num_sequences": args.max_num_sequences,
-            "max_input_len": args.max_input_len,
+            "max_num_batched_tokens": args.max_num_batched_tokens,
             "min_decode_steps": args.min_decode_steps,
             "max_decode_steps": args.max_decode_steps,
         }
@@ -134,8 +133,7 @@ if __name__ == "__main__":
     postproc_mlc_serve_args(args)
 
     if args.long_prompt:
-        args.max_input_len = 10000
-        args.max_num_sequences = 5
+        args.max_num_batched_tokens = 50000
 
     if args.num_sequences_to_sample > 1:
         args.use_random_sampling = True

--- a/serve/tests/unittest/test_engine_init.py
+++ b/serve/tests/unittest/test_engine_init.py
@@ -16,8 +16,7 @@ def _test_insufficient_cache_blocks_fail(artifact_path):
         engine_config = get_engine_config(
             {
                 "use_staging_engine": False,
-                "max_num_sequences": max_num_seqs,
-                "max_input_len": 16384,
+                "max_num_batched_tokens": 16384 * max_num_seqs,
                 "min_decode_steps": 12,
                 "max_decode_steps": 16,
             }

--- a/serve/tests/unittest/test_engine_with_samplers.py
+++ b/serve/tests/unittest/test_engine_with_samplers.py
@@ -17,14 +17,12 @@ from mlc_serve.utils import get_default_mlc_serve_argparser, postproc_mlc_serve_
 def create_engine(
     model_artifact_path,
     use_staging_engine,
-    max_num_sequences,
-    max_input_len,
+    max_num_batched_tokens,
 ):
     engine_config = get_engine_config(
         {
             "use_staging_engine": use_staging_engine,
-            "max_num_sequences": max_num_sequences,
-            "max_input_len": max_input_len,
+            "max_num_batched_tokens": max_num_batched_tokens,
             # Use defaults for "min_decode_steps", "max_decode_steps"
         }
     )
@@ -69,8 +67,7 @@ def create_request(
 def _test_max_tokens(
     model_artifact_path,
     use_staging_engine,
-    max_num_sequences=4,
-    max_input_len=512,
+    max_num_batched_tokens=2048,
     num_requests=5,
     ignore_eos=False,
 ):
@@ -78,8 +75,7 @@ def _test_max_tokens(
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_sequences,
-        max_input_len,
+        max_num_batched_tokens,
     )
 
     requests = [
@@ -131,8 +127,7 @@ def _test_max_context_length(
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_sequences,
-        max_input_len=max_context_length,
+        max_num_batched_tokens=max_context_length * max_num_sequences,
     )
     prompt = "hi " * (max_context_length - 15)
 
@@ -171,16 +166,14 @@ def _test_max_context_length(
 def _test_ignore_eos(
     model_artifact_path,
     use_staging_engine,
-    max_num_sequences=4,
-    max_input_len=512,
+    max_num_batched_tokens=2048,
     num_requests=5,
 ):
     prompt = "hi"
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_sequences,
-        max_input_len,
+        max_num_batched_tokens,
     )
     s = 113
     requests = [
@@ -222,16 +215,14 @@ def _test_ignore_eos(
 def _test_stop(
     model_artifact_path,
     use_staging_engine,
-    max_num_sequences=4,
-    max_input_len=512,
+    max_num_batched_tokens=2048,
     num_requests=5,
 ):
     prompt = "Write a merge sort program in Python."
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_sequences,
-        max_input_len,
+        max_num_batched_tokens,
     )
     requests = []
     for n, stop in enumerate(["\n", ["\n"], "\n\n", "!", ["n", "!"]]):
@@ -285,8 +276,7 @@ def _test_stop(
 def _test_penalty(
     model_artifact_path,
     use_staging_engine,
-    max_num_sequences=4,
-    max_input_len=512,
+    max_num_batched_tokens=2048,
     num_requests=5,
     ignore_eos=False,
 ):
@@ -294,8 +284,7 @@ def _test_penalty(
     engine = create_engine(
         model_artifact_path,
         use_staging_engine,
-        max_num_sequences,
-        max_input_len,
+        max_num_batched_tokens,
     )
 
     random_requests = [

--- a/serve/tests/unittest/test_staging_engine.py
+++ b/serve/tests/unittest/test_staging_engine.py
@@ -220,8 +220,7 @@ def test_cache_evict_hang_staging():
         model_module_loader=DummyModelModule,
         model_module_loader_kwargs = {
             "max_cached_tokens": 40,
-            "max_input_len": 10,
-            "max_num_sequences": 2
+            "max_num_batched_tokens": 20,
         }
         )
     engine.start()
@@ -277,8 +276,7 @@ def test_big_prompt_fit_to_cache_staging():
         model_module_loader=DummyModelModule,
         model_module_loader_kwargs = {
             "max_cached_tokens": 40,
-            "max_input_len": 30,
-            "max_num_sequences": 1
+            "max_num_batched_tokens": 30,
         }
         )
     engine.start()
@@ -319,8 +317,7 @@ def test_big_prompt_not_fit_to_cache():
         model_module_loader=DummyModelModule,
         model_module_loader_kwargs = {
             "max_cached_tokens": 29,
-            "max_input_len": 30,
-            "max_num_sequences": 1
+            "max_num_batched_tokens": 30,
         }
         )
     engine.start()

--- a/serve/tests/unittest/test_sync_engine.py
+++ b/serve/tests/unittest/test_sync_engine.py
@@ -166,7 +166,7 @@ def test_multiple_requests_preempt():
 # state exceeding the max_num_batched_tokens can be processed successfully and will
 # not hang the server in infinite attempt to return it back to the active loop
 def test_cache_evict_hang():
-    engine = SynchronousInferenceEngine(DummyModelModule(40, 10, 2))
+    engine = SynchronousInferenceEngine(DummyModelModule(40, 20))
 
     request_id_1 = "1"
     request_id_2 = "2"
@@ -213,7 +213,7 @@ def test_cache_evict_hang():
 # Test to verify if new comming request with big prompt can be put into inference
 # and does not have issues with cache size limits verification
 def test_big_prompt_fit_to_cache():
-    engine = SynchronousInferenceEngine(DummyModelModule(40, 30, 1))
+    engine = SynchronousInferenceEngine(DummyModelModule(40, 30))
 
     request_id_1 = "1"
 
@@ -245,7 +245,7 @@ def test_big_prompt_fit_to_cache():
 
 # Test to verify if new comming request with big prompt is handled properly
 def test_big_prompt_not_fit_to_cache():
-    engine = SynchronousInferenceEngine(DummyModelModule(29, 30, 1))
+    engine = SynchronousInferenceEngine(DummyModelModule(29, 30))
 
     request_id_1 = "1"
 


### PR DESCRIPTION
This PR removes `max_input_len` and `max_num_sequences`. User should specify `max_num_batched_tokens` instead.

cc @sunggg @masahi 