### PR TITLE
Add structured error type when asset does not exist.

### DIFF
--- a/serve/mlc_serve/model/base.py
+++ b/serve/mlc_serve/model/base.py
@@ -32,7 +32,9 @@ class ModelArtifactConfig:
         )
 
 class AssetNotFound(Exception):
-    pass
+    def __init__(self, asset_path):
+        self.asset_path = asset_path
+        super().__init__(f"{self.asset_path} should exist. Did you build with `--enable-batching`?")
 
 def get_model_artifact_config(model_artifact_path):
     json_object = {"model_artifact_path": model_artifact_path}
@@ -42,7 +44,7 @@ def get_model_artifact_config(model_artifact_path):
     ]:
         config_file_path = os.path.join(model_artifact_path, config_file_name)
         if not os.path.exists(config_file_path):
-            raise AssetNotFound(f"{config_file_path} should exist. Did you build with `--enable-batching`?")
+            raise AssetNotFound(config_file_path)
 
         with open(config_file_path, mode="rt", encoding="utf-8") as f:
             json_object.update(json.load(f))

--- a/serve/mlc_serve/model/base.py
+++ b/serve/mlc_serve/model/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
-import os 
+import os
 import json
 import inspect
 
@@ -31,16 +31,20 @@ class ModelArtifactConfig:
             }
         )
 
+class AssetNotFound(Exception):
+    pass
+
 def get_model_artifact_config(model_artifact_path):
     json_object = {"model_artifact_path": model_artifact_path}
-    for config_file_name in [ 
+    for config_file_name in [
         "build_config.json",
         "model/mlc-model-config.json"
     ]:
         config_file_path = os.path.join(model_artifact_path, config_file_name)
-        assert os.path.exists(config_file_path), f"{config_file_path} should exist. Did you build with `--enable-batching`?"
+        if not os.path.exists(config_file_path):
+            raise AssetNotFound(f"{config_file_path} should exist. Did you build with `--enable-batching`?")
+
         with open(config_file_path, mode="rt", encoding="utf-8") as f:
             json_object.update(json.load(f))
-    
+
     return ModelArtifactConfig._from_json(json_object)
-    


### PR DESCRIPTION
This is there so we can catch the error on load. 