### PR TITLE
KV cache refactor to decouple cache blocks and metadata about them

### DIFF
--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -24,6 +24,7 @@ def get_default_mlc_serve_argparser(description="", allow_override=False):
     parser.add_argument("--artifact-path", type=str, default="dist")
     parser.add_argument("--use-sync-engine", action="store_true")
     parser.add_argument("--max-num-batched-tokens", type=int, default=4096)
+    parser.add_argument("--num-sequences-to-sample", type=int, default=1)
     parser.add_argument("--min-decode-steps", type=int, default=32)
     parser.add_argument("--max-decode-steps", type=int, default=56)
     parser.add_argument("--debug-logging", action="store_true")


### PR DESCRIPTION
Right now we are attaching both cache blocks and metadata about them such as `block_table` into a single class which is passed back and forth between the engine and the model. While working on multi-gpu support for PT models, I learned that I need to use some RPC framework to manage multiple processes. 

The inputs from the engine need to cross the RPC boundary on each inference, and it is a bit awkward if the actual cache blocks also need to be passed from the engine always for no reason. For disco, only a handle to the cache blocks (`DRef`) is communicated between the engine and the model, but even this is unnecessary. 

With this PR, the cache blocks are completely owned by the model and only `block_tables` etc need to be passed from the engine. I renamed the class to `KVCacheInfo` to reflect its new role. The interface in `model_module.py` doesn't need to change since this change is impl details of the paged cache model.

@yelite 