### PR TITLE
[Mixtral] Use col major for MoE gemm and use small batch specialization

### DIFF
--- a/mlc_llm/relax_model/mixtral.py
+++ b/mlc_llm/relax_model/mixtral.py
@@ -18,7 +18,7 @@ class MoELinear(nn.Module):
         if config.quantization_scheme.name == "q0f16":
             # weight is row major
             self.weight = nn.Parameter(
-                (num_experts, in_features, out_features),
+                (num_experts, out_features, in_features),
                 dtype="float16",
             )
         elif config.quantization_scheme.name == "q4f16_ft":


### PR DESCRIPTION
Changed MoE gemm to use more performant col major layouts. Also cleaned up param loading hack for mixtral that previously used PyTorch for fast weight transposition.

Benchmark: https://docs.google.com/spreadsheets/d/1w1uYvBK9bZluue4uyZjgT_4e8tl0rQDfMZ2XQfg43f4/edit#gid=0

need the commit https://github.com/octoml/tvm/commit/7fb6b704879f5accaf3ff08c96409123a02b8f58

cc @sunggg @masahi 