### PR TITLE
Update model definition to support Flash-Decoding

### DIFF
--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -457,8 +457,7 @@ def run(args):
     head_size = config.hidden_size // config.num_attention_heads
     num_blocks = 500
 
-    # TODO: check KV type is flash decode
-    use_flash_decoding = True
+    use_flash_decoding = False
 
     if use_flash_decoding:
         allocate_func_name = "tvm.contrib.flash_attn.allocate_kv_cache"

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -546,45 +546,46 @@ def run(args):
 
             logits_offset += query_token_len
 
-    # query_token_lens = [4, 3, 5, 2]
-    # func_name = "evaluate_multi_query"
+    query_token_lens = [4, 3, 5, 2]
+    func_name = "evaluate_multi_query"
 
-    # eval_query_requests = []
+    eval_query_requests = []
 
-    # for request_id, query_token_len in zip(request_ids, query_token_lens):
-    #     queries_to_eval = requests[request_id].token_ids[-query_token_len:]
-    #     num_past = len(requests[request_id].token_ids) - query_token_len
-    #     eval_query_requests.append(EvalQueryRequest(request_id, num_past, queries_to_eval))
+    for request_id, query_token_len in zip(request_ids, query_token_lens):
+        queries_to_eval = requests[request_id].token_ids[-query_token_len:]
+        num_past = len(requests[request_id].token_ids) - query_token_len
+        eval_query_requests.append(EvalQueryRequest(request_id, num_past, queries_to_eval))
 
-    # (
-    #     input_ids,
-    #     positions,
-    #     seq_lens,
-    #     slot_mapping,
-    #     query_lens,
-    #     past_slot_mapping,
-    #     permute_map,
-    # ) = _prepare_eval_queries(
-    #     eval_query_requests,
-    #     cache.slot_mappings,
-    #     None,
-    #     model.dev,
-    # )
+    (
+        input_ids,
+        positions,
+        seq_lens,
+        slot_mapping,
+        query_lens,
+        past_slot_mapping,
+        permute_map,
+    ) = _prepare_eval_queries(
+        eval_query_requests,
+        cache.slot_mappings,
+        None,
+        model.dev,
+    )
 
-    # logits = model.mod[func_name](
-    #     input_ids,
-    #     positions,
-    #     seq_lens,
-    #     cache.cache,
-    #     slot_mapping,
-    #     query_lens,
-    #     past_slot_mapping,
-    #     permute_map,
-    #     model.params,
-    # )[0].numpy()
+    logits = model.mod[func_name](
+        input_ids,
+        positions,
+        seq_lens,
+        cache.cache,
+        slot_mapping,
+        query_lens,
+        past_slot_mapping,
+        permute_map,
+        model.params,
+    )[0].numpy()
 
-    # verify_logits(logits, query_token_lens)
+    verify_logits(logits, query_token_lens)
 
+    return
     query_token_lens = [3, 3, 3, 3]
     func_name = "decode_multi_query"
 

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -28,11 +28,10 @@ class KVCache:
 
 
 class CacheManager:
-    block_size: int = 16
-
     def __init__(
-        self, num_blocks, num_layers, num_heads, head_size, init_cache_func, sliding_window=None
+        self, num_blocks, block_size, num_layers, num_heads, head_size, init_cache_func, sliding_window=None
     ):
+        self.block_size = block_size
         self.num_blocks = num_blocks
         self.free_blocks = list(range(num_blocks))
         self.kv_cache = KVCache(
@@ -455,14 +454,17 @@ def run(args):
 
     num_kv_heads = config.get_num_key_value_heads() // args.num_shards
     head_size = config.hidden_size // config.num_attention_heads
-    num_blocks = 500
 
-    use_flash_decoding = False
+    use_flash_decoding = True
 
     if use_flash_decoding:
         allocate_func_name = "tvm.contrib.flash_attn.allocate_kv_cache"
+        block_size = 256
+        num_blocks = 30
     else:
         allocate_func_name = "tvm.contrib.vllm.allocate_kv_cache"
+        block_size = 16
+        num_blocks = 500
 
     if model.disco_session:
         init_cache_func = model.disco_session.get_global_func(allocate_func_name)
@@ -471,6 +473,7 @@ def run(args):
 
     cache_manager = CacheManager(
         num_blocks,
+        block_size,
         config.num_hidden_layers,
         num_kv_heads,
         head_size,
@@ -546,46 +549,46 @@ def run(args):
 
             logits_offset += query_token_len
 
-    query_token_lens = [4, 3, 5, 2]
-    func_name = "evaluate_multi_query"
+    # query_token_lens = [4, 3, 5, 2]
+    # func_name = "evaluate_multi_query"
 
-    eval_query_requests = []
+    # eval_query_requests = []
 
-    for request_id, query_token_len in zip(request_ids, query_token_lens):
-        queries_to_eval = requests[request_id].token_ids[-query_token_len:]
-        num_past = len(requests[request_id].token_ids) - query_token_len
-        eval_query_requests.append(EvalQueryRequest(request_id, num_past, queries_to_eval))
+    # for request_id, query_token_len in zip(request_ids, query_token_lens):
+    #     queries_to_eval = requests[request_id].token_ids[-query_token_len:]
+    #     num_past = len(requests[request_id].token_ids) - query_token_len
+    #     eval_query_requests.append(EvalQueryRequest(request_id, num_past, queries_to_eval))
 
-    (
-        input_ids,
-        positions,
-        seq_lens,
-        slot_mapping,
-        query_lens,
-        past_slot_mapping,
-        permute_map,
-    ) = _prepare_eval_queries(
-        eval_query_requests,
-        cache.slot_mappings,
-        None,
-        model.dev,
-    )
+    # (
+    #     input_ids,
+    #     positions,
+    #     seq_lens,
+    #     slot_mapping,
+    #     query_lens,
+    #     past_slot_mapping,
+    #     permute_map,
+    # ) = _prepare_eval_queries(
+    #     eval_query_requests,
+    #     cache.slot_mappings,
+    #     None,
+    #     model.dev,
+    # )
 
-    logits = model.mod[func_name](
-        input_ids,
-        positions,
-        seq_lens,
-        cache.cache,
-        slot_mapping,
-        query_lens,
-        past_slot_mapping,
-        permute_map,
-        model.params,
-    )[0].numpy()
+    # logits = model.mod[func_name](
+    #     input_ids,
+    #     positions,
+    #     seq_lens,
+    #     cache.cache,
+    #     slot_mapping,
+    #     query_lens,
+    #     past_slot_mapping,
+    #     permute_map,
+    #     model.params,
+    # )[0].numpy()
 
-    verify_logits(logits, query_token_lens)
+    # verify_logits(logits, query_token_lens)
 
-    return
+    # return
     query_token_lens = [3, 3, 3, 3]
     func_name = "decode_multi_query"
 

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -577,8 +577,6 @@ def run(args):
             logits_offset += query_token_len
 
     query_token_lens = [4, 3, 5, 2]
-    func_name = "evaluate_multi_query"
-
     eval_query_requests = []
 
     for request_id, query_token_len in zip(request_ids, query_token_lens):
@@ -601,7 +599,7 @@ def run(args):
         model.dev,
     )
 
-    logits = model.mod[func_name](
+    logits = model.mod["evaluate_multi_query"](
         input_ids,
         positions,
         seq_lens,
@@ -619,10 +617,7 @@ def run(args):
         return
 
     query_token_lens = [3, 3, 3, 3]
-    func_name = "decode_multi_query"
-
     decode_multi_query_requests = requests
-
     query_len = query_token_lens[0]
 
     (
@@ -644,7 +639,7 @@ def run(args):
 
     input_ids = tvm.nd.array(np.reshape(input_ids.numpy(), [-1, query_len]), dev)
 
-    logits = model.mod[func_name](
+    logits = model.mod["decode_multi_query"](
         input_ids,
         positions,
         seq_lens,

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -196,7 +196,7 @@ def _prepare_inputs(
                 start_idx += prompt_len
 
         else:
-            input_ids += token_ids[:-query_token_len]
+            input_ids += token_ids[-query_token_len:]
 
             for i in range(query_token_len):
                 positions.append(len(token_ids) - (query_token_len - i))

--- a/examples/python/run_llama_batched_vllm.py
+++ b/examples/python/run_llama_batched_vllm.py
@@ -338,7 +338,6 @@ class Model:
         self.sliding_window = sliding_window
 
         if sliding_window:
-            # TODO
             self.block_sliding_window = sliding_window // block_size
         else:
             self.block_sliding_window = None
@@ -424,12 +423,10 @@ class Model:
 
 def get_paged_kv_cache_type(model_artifact_path):
     config_file_path = os.path.join(model_artifact_path, "build_config.json")
-
     assert os.path.exists(config_file_path)
 
     with open(config_file_path, mode="rt", encoding="utf-8") as f:
         build_cfg = json.load(f)
-
         return build_cfg["paged_kv_cache_type"]
 
 
@@ -469,7 +466,6 @@ def run(args):
         config = LlamaConfig(**json.load(i_f))
 
     kv_type = get_paged_kv_cache_type(args.artifact_path)
-
     use_flash_decoding = kv_type == "flash-decoding"
 
     if use_flash_decoding:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -392,6 +392,7 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    # TODO(masahi): Remove the use of this option with paged_kv_cache_type
     use_vllm_attention: bool = field(
         default=False,
         metadata={

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -402,6 +402,10 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    paged_kv_cache_type: str = field(
+        default="vllm",
+        metadata={"help": "The type of paged KV cache, either vllm or flash-decoding"},
+    )
 
     @property
     def convert_weight_only(self):
@@ -595,6 +599,9 @@ def mod_transform_before_build(
             model_names.append("evaluate")
             model_names.append("evaluate_multi_query")
 
+            if args.paged_kv_cache_type == "flash-decoding":
+                model_names.append("decode_multi_query")
+
         if args.sep_embed:
             model_names = ["embed", "prefill_with_embed"] + model_names[1:]
             if args.enable_batching:
@@ -706,6 +713,7 @@ def dump_build_config(
     config: Dict[str, Any] = {
         "num_shards": args.num_shards,
         "quantization": args.quantization.name,
+        "paged_kv_cache_type": args.paged_kv_cache_type,
         "library_name": args.lib_name,
         "build_options": str(args)
     }

--- a/mlc_llm/relax_model/llama_batched_vllm.py
+++ b/mlc_llm/relax_model/llama_batched_vllm.py
@@ -140,7 +140,7 @@ class LlamaAttentionBatched(LlamaAttentionBase):
                 slot_mapping = attn_input.slot_mapping
 
             # kv caches are updated inplace, but make it look like a pure operation
-            if self.kv_type == KVCacheType.FlashDecoding:
+            if self.kv_type == KVCacheType.VLLM:
                 kv = nn.emit(
                     relax.op.call_pure_packed(
                         "tvm.contrib.vllm.reshape_and_cache",
@@ -177,7 +177,7 @@ class LlamaAttentionBatched(LlamaAttentionBase):
             kv_shape = (num_past_token, num_kv_head, head_size)
             kv_sinfo = relax.TensorStructInfo(kv_shape, k_cache.struct_info.dtype)
 
-            if self.kv_type == KVCacheType.FlashDecoding:
+            if self.kv_type == KVCacheType.VLLM:
                 kv_tensors = nn.emit(
                     relax.op.call_pure_packed(
                         "tvm.contrib.vllm.reconstruct_from_cache",

--- a/mlc_llm/relax_model/llama_batched_vllm.py
+++ b/mlc_llm/relax_model/llama_batched_vllm.py
@@ -174,10 +174,10 @@ class LlamaAttentionBatched(LlamaAttentionBase):
 
             if self.kv_type == KVCacheType.VLLM:
                 num_kv_head = v_cache.struct_info.shape[1]
+                head_size = v_cache.struct_info.shape[2]
             else:
                 num_kv_head = v_cache.struct_info.shape[2]
-
-            head_size = v_cache.struct_info.shape[-1]
+                head_size = v_cache.struct_info.shape[-1]
 
             num_past_token = attn_input.aux_info.past_slot_mapping.struct_info.shape[0]
             kv_shape = (num_past_token, num_kv_head, head_size)
@@ -794,20 +794,20 @@ def create_decoding_func(
     func_name = "decode"
 
     num_seq = tvm.tir.SizeVar("num_seq", "int64")
-    seqlen_q = tvm.tir.SizeVar("seqlen_q", "int64")
 
-    seqlen_q_info = [("decode", 1)]
+    func_names = ["decode"]
 
     if kv_type == KVCacheType.FlashDecoding:
-        seqlen_q_info.append(("decode_multi_query", seqlen_q))
+        func_names.append("decode_multi_query")
 
-    for (func_name, seqlen_q) in seqlen_q_info:
+    for func_name in func_names:
         max_num_blocks_per_seq = tvm.tir.SizeVar("max_num_blocks_per_seq", "int64")
 
-        if seqlen_q == 1:
+        if func_name == "decode":
             num_query_token = num_seq
             input_shape = (num_query_token,)
         else:
+            seqlen_q = tvm.tir.SizeVar("seqlen_q", "int64")
             num_query_token = num_seq * seqlen_q
             input_shape = (num_seq, seqlen_q)
 


### PR DESCRIPTION
This PR integrates Flash-Decoding support from https://github.com/apache/tvm/pull/16474. This is a drop-in replacement for the vLLM kernel. The only difference with the vLLM-based build is the shape of KV cache blocks. In particular, the block size for vLLM is 16 while for Flash-Decoding it is 256. 

In addition, it supports decoding with multiple, fixed length queries per request, which is necessary for speculative decoding. `evaluate_multi_query` from https://github.com/octoml/mlc-llm/pull/156 can also be used for this purpose, but it supports variable-length queries per request and piggy-backs to the prefill attention, which is not efficient when the number of queries is fixed and small. The changes in `run_llama_batched_vllm.py` demonstrates that the new Relax function, `decode_multi_query`, can do exactly the same thing as `evaluate_multi_query` when the query length is fixed.

This PR only updates the model definition and `run_llama_batched_vllm.py` example script. I'll follow up with the integration into `mlc-serve` next. 
 
Need the latest https://github.com/octoml/tvm/tree/for-mlc-serve-jan12

@sunggg @yelite @vinx13 