### PR TITLE
Fix GPU-CPU tensor manipulation. Small performance boost

### DIFF
--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -84,11 +84,8 @@ def sample(
         mask_random_dvc = mask_random_cpu
         mask_greedy_dvc = mask_greedy_cpu
     else:  # gpu
-        mask_random_dvc = torch.tensor(
-            [p.sampling_type == SamplingType.RANDOM for p in sampling_params],
-            dtype=torch.bool, device=logits.device
-        )
-        mask_greedy_dvc = torch.logical_not(mask_random_dvc)
+        mask_random_dvc = mask_random_cpu.to(logits.device)
+        mask_greedy_dvc = mask_greedy_cpu.to(logits.device)
 
     logits_greedy = logits[mask_greedy_dvc]
 

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -75,13 +75,13 @@ def sample(
     logits = torch.from_dlpack(logits)
     num_seq = len(sampling_params)
 
-    mask_random = torch.tensor(
+    mask_random_dvc = torch.tensor(
         [p.sampling_type == SamplingType.RANDOM for p in sampling_params],
         dtype=torch.bool, device=logits.device
     )
-    mask_greedy = torch.logical_not(mask_random)
+    mask_greedy_dvc = torch.logical_not(mask_random_dvc)
 
-    logits_greedy = logits[mask_greedy]
+    logits_greedy = logits[mask_greedy_dvc]
 
     if logits_greedy.shape[0] > 0:
         res_greedy = torch.argmax(logits_greedy, -1).cpu().numpy()
@@ -140,7 +140,7 @@ def sample(
                     .to(device=logits.device)
                 )
 
-    logits_random = logits[mask_random]
+    logits_random = logits[mask_random_dvc]
 
     if divide_by_temperature:
         t = torch.tensor(temperatures, dtype=logits.dtype, device=logits.device)

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -77,7 +77,7 @@ def sample(
 
     mask_random_cpu = torch.tensor(
         [p.sampling_type == SamplingType.RANDOM for p in sampling_params],
-        dtype=torch.bool
+        dtype=torch.bool,
     )
     mask_greedy_cpu = torch.logical_not(mask_random_cpu)
     if logits.device == torch.device("cpu"):

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -77,7 +77,7 @@ def sample(
 
     mask_random = torch.tensor(
         [p.sampling_type == SamplingType.RANDOM for p in sampling_params],
-        dtype=torch.bool,
+        dtype=torch.bool, device=logits.device
     )
     mask_greedy = torch.logical_not(mask_random)
 

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -161,11 +161,16 @@ def sample(
         torch.cuda.nvtx.range_pop()
         return res_random
 
+    mask_random_cpu = torch.tensor(
+        [p.sampling_type == SamplingType.RANDOM for p in sampling_params],
+        dtype=torch.bool
+    )
+    mask_greedy_cpu = torch.logical_not(mask_random_cpu)
     res = np.empty((num_seq,), dtype=np.int32)
-    res[mask_random] = res_random
+    res[mask_random_cpu] = res_random
 
     if logits_greedy.shape[0] > 0:
-        res[mask_greedy] = res_greedy
+        res[mask_greedy_cpu] = res_greedy
 
     torch.cuda.nvtx.range_pop()
     return res

--- a/serve/mlc_serve/model/model_common.py
+++ b/serve/mlc_serve/model/model_common.py
@@ -155,7 +155,7 @@ def sample(
         torch.cuda.nvtx.range_pop()
         return None
 
-    res_random = torch.multinomial(probs, 1, True).cpu().numpy()[:, 0]
+    res_random = torch.multinomial(probs, 1, True)[:, 0].cpu().numpy()
 
     if logits_random.shape[0] == num_seq:
         torch.cuda.nvtx.range_pop()


### PR DESCRIPTION
There are two fixes:
1. Greedy and random masks are created on CPU side, but are used on both CPU and GPU sides, particularly it selects `logits` from GPU (potential performance reduction). After fix there are two pairs of masks on CPU and `logits` device side, moreover CPU masks are created only if it needs.
2. Replace `res_random = torch.multinomial(probs, 1, True).cpu().numpy()[:, 0]` by `res_random = torch.multinomial(probs, 1, True)[:, 0].cpu().numpy()`. As I understand in the first case we copy the slice from old numpy to new one after copying full tensor from GPU to CPU, but in the second case we get slice view (without memory copying) and copying from GPU to CPU only sliced tensor (not full)

Results of benchmark:
```
MISTRAL (python serve/benchmarks/benchmark_throughput.py --local-id mistral-7b-instruct-q0f16-presharded-1gpu --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --seed 0 --num-prompts 1000)

batch-serving:
Engine Throughput: 49.18 requests/s, 18816.81 tokens/s
Engine Throughput: 48.36 requests/s, 18503.69 tokens/s
Engine Throughput: 48.79 requests/s, 18668.08 tokens/s
AVERAGE: 48.78 requests/s, 18662.86 tokens/s

Fix 1:
Engine Throughput: 48.92 requests/s, 18717.29 tokens/s
Engine Throughput: 49.37 requests/s, 18891.61 tokens/s
Engine Throughput: 48.73 requests/s, 18647.23 tokens/s
AVERAGE: 49.01 requests/s, 18752.04 tokens/s

Fix1 + Fix2:
Engine Throughput: 49.23 requests/s, 18837.64 tokens/s
Engine Throughput: 49.43 requests/s, 18911.63 tokens/s
Engine Throughput: 50.00 requests/s, 19130.03 tokens/s
AVERAGE: 49.55 requests/s, 18959.77 tokens/s

MIXTRAL (python serve/benchmarks/benchmark_throughput.py --local-id mixtral-8x7b-instruct-v0.1-q0f16-presharded-2gpu --dataset /opt/models/dataset/ShareGPT_V3_unfiltered_cleaned_split.json --seed 0 --num-prompts 1000)

batch-serving:
Engine Throughput: 23.71 requests/s, 9073.14 tokens/s
Engine Throughput: 23.62 requests/s, 9038.81 tokens/s
Engine Throughput: 23.44 requests/s, 8970.07 tokens/s
AVERAGE: 23.59 requests/s, 9027.34 tokens/s

Fix1 + Fix2:
Engine Throughput: 23.69 requests/s, 9064.93 tokens/s
Engine Throughput: 23.64 requests/s, 9045.66 tokens/s
Engine Throughput: 23.58 requests/s, 9022.22 tokens/s
AVERAGE: 23.64 requests/s, 9044.27 tokens/s
```

**Note:** Fluctuation of time from run to run is big enough (~1-2%) therefore several runs were performed and averaged, possibly measurements should be more careful