### PR TITLE
Prevent worker process from running after main process exits with error

### DIFF
--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -65,14 +65,14 @@ class AsyncEngineConnector:
                 raise
             finally:
                 self.shutdown_event.set()
+                if isinstance(self.engine, ScopedInferenceEngine):
+                    await asyncio.to_thread(self.engine.stop)
 
         self.engine_loop_task = asyncio.create_task(wait())
 
     async def stop(self):
         self.engine_loop_task.cancel()
         await self.engine_loop_task
-        if isinstance(self.engine, ScopedInferenceEngine):
-            await asyncio.to_thread(self.engine.stop)
 
     async def generate(self, request: Request) -> AsyncIterator[RequestOutput]:
         try:

--- a/serve/mlc_serve/engine/staging_engine_worker.py
+++ b/serve/mlc_serve/engine/staging_engine_worker.py
@@ -386,7 +386,7 @@ def run_generation_loop_worker(
         should_stop = True
 
     handler_thread = Thread(
-        target=handle_command, name="staging-engine-worker-command-handler"
+        target=handle_command, name="staging-engine-worker-command-handler", daemon=True
     )
     handler_thread.start()
 
@@ -411,5 +411,3 @@ def run_generation_loop_worker(
             # result_queue should have size limit and the blocking behavior
             # of queue.put will naturally limits the tokens it generates ahead of time.
             result_queue.put(output)
-
-    handler_thread.join()


### PR DESCRIPTION
Each of the change in `async_connector.py` and `staging_engine_worker.py` can fix the issue. I apply both changes in this PR because they are reasonable on their own.

1. The change in `async_connector.py` makes sure the engine will be stopped whenever it exits the inference loop.
2. The change in `staging_engine_worker.py` makes the process exit after the computation loop exits, even if the message handler thread is still running.

cc @sunggg @masahi 