### PR TITLE
[MLS-272] Fix Special Token Encode Difference

### DIFF
--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -170,8 +170,11 @@ class TextGenerator(Protocol):
 class Tokenizer(Protocol):
     _tokenizer: Any
     eos_token_id: int
-    skip_special_tokens: bool # for decoder
-    add_special_tokens: bool # for encoder
+    # Whether or not to remove special tokens in the decoding.
+    skip_special_tokens: bool
+    # Whether or not to add special tokens when encoding the sequences.
+    # Special tokens are relative to models like [CLS] and [SEP]
+    add_special_tokens: bool
     all_special_ids: List[int]
     is_fast: bool
 

--- a/serve/mlc_serve/engine/model_module.py
+++ b/serve/mlc_serve/engine/model_module.py
@@ -170,7 +170,8 @@ class TextGenerator(Protocol):
 class Tokenizer(Protocol):
     _tokenizer: Any
     eos_token_id: int
-    skip_special_tokens: bool
+    skip_special_tokens: bool # for decoder
+    add_special_tokens: bool # for encoder
     all_special_ids: List[int]
     is_fast: bool
 

--- a/serve/mlc_serve/model/tokenizer.py
+++ b/serve/mlc_serve/model/tokenizer.py
@@ -5,15 +5,23 @@ from pathlib import Path
 
 
 class Tokenizer:
-    def __init__(self, hf_tokenizer, skip_special_tokens=True):
+    def __init__(
+            self,
+            hf_tokenizer,
+            skip_special_tokens=True, # for decoder
+            add_special_tokens=False # for encoder
+        ):
         self._tokenizer = hf_tokenizer
         self.eos_token_id = self._tokenizer.eos_token_id
+        self.add_special_tokens = add_special_tokens
         self.skip_special_tokens = skip_special_tokens
         self.all_special_ids = self._tokenizer.all_special_ids
         self.is_fast = self._tokenizer.is_fast
 
     def encode(self, text: str) -> List[int]:
-        return self._tokenizer.encode(text)
+        return self._tokenizer.encode(
+            text, add_special_tokens=self.add_special_tokens
+        )
 
     def decode(self, token_ids: List[int]) -> str:
         return self._tokenizer.decode(

--- a/serve/mlc_serve/model/tokenizer.py
+++ b/serve/mlc_serve/model/tokenizer.py
@@ -8,8 +8,8 @@ class Tokenizer:
     def __init__(
             self,
             hf_tokenizer,
-            skip_special_tokens=True, # for decoder
-            add_special_tokens=False # for encoder
+            skip_special_tokens=True, # for decode function
+            add_special_tokens=False # for encode function
         ):
         self._tokenizer = hf_tokenizer
         self.eos_token_id = self._tokenizer.eos_token_id


### PR DESCRIPTION
Currently in MLC Serve, we may encounter slightly different input tokens compare to expected due to the handling of special tokens. Take the recent codellama 70b model as an example, in the [official document](https://huggingface.co/codellama/CodeLlama-70b-Instruct-hf#chat-prompt), a chat example is given as follows:
```
chat = [
    {"role": "system", "content": "System prompt    "},
    {"role": "user", "content": "First user query"},
    {"role": "assistant", "content": "Model response to first query"},
    {"role": "user", "content": "Second user query"},
]

```
After tokenizer's template application `tokenizer.apply_chat_template(chat, tokenize=False)` it becomes
```
'<s>Source: system\n\n System prompt <step> Source: user\n\n First user query <step> Source: assistant\n\n Model response to first query <step> Source: user\n\n Second user query <step> Source: assistant\nDestination: user\n\n '
``` 
And the reference of generated token is:
```
reference_tokens = [1, 7562, 29901, 1788, 13, 13, 2184, 9508, 32015, 7562, 29901, 1404, 13, 13, 3824, 1404, 2346, 32015, 7562, 29901, 20255, 13, 13, 8125, 2933, 304, 937, 2346, 32015, 7562, 29901, 1404, 13, 13, 6440, 1404, 2346, 32015, 7562, 29901, 20255, 13, 14994, 3381, 29901, 1404, 13, 13, 29871]
```

However, in our implementation, even if the generated prompt is the same
```
'<s>Source: system\n\n System prompt <step> Source: user\n\n First user query <step> Source: assistant\n\n Model response to first query <step> Source: user\n\n Second user query <step> Source: assistant\nDestination: user\n\n '
```
The generated token has an extra token `1` in the beginning
```
[1, 1, 7562, 29901, 1788, 13, 13, 2184, 9508, 32015, 7562, 29901, 1404, 13, 13, 3824, 1404, 2346, 32015, 7562, 29901, 20255, 13, 13, 8125, 2933, 304, 937, 2346, 32015, 7562, 29901, 1404, 13, 13, 6440, 1404, 2346, 32015, 7562, 29901, 20255, 13, 14994, 3381, 29901, 1404, 13, 13, 29871]
```
The difference comes from the different usage of the `add_special_tokens` option when doing tokenizer encoding. The `transformers` lib's `apply_chat_template` function uses `add_special_tokens=False` as default when doing tokenization, code can be found [here](https://github.com/huggingface/transformers/blob/58e3d23e97078f361a533b9ec4a6a2de674ea52a/src/transformers/tokenization_utils_base.py#L1751). This PR uses the same option default and can get the same generated token as official reference code.

Also it remains a question whether we should adopt `apply_chat_template` function as a potential way to do chat template application and tokenization using tokenizer directly.

CC @sunggg 