### PR TITLE
ModelArtifactConfig creation refactor

### DIFF
--- a/serve/mlc_serve/api/handler.py
+++ b/serve/mlc_serve/api/handler.py
@@ -49,14 +49,11 @@ router = APIRouter()
 def _get_sampling_params(
     request: ChatCompletionRequest, model_artifact_config: ModelArtifactConfig
 ) -> SamplingParams:
-    sampling_params = SamplingParams(
-        # These params came from vllm
-        # TODO(amnalyshe): should they be put into mlc-llm batch serving ChatCompletionRequest?
-        # best_of=request.best_of,
-        # top_k=request.top_k,
-        # ignore_eos=request.ignore_eos,
-        # use_beam_search=request.use_beam_search,
-    )
+    sampling_params = SamplingParams()
+    assert model_artifact_config.vocab_size is not None
+    sampling_params.vocab_size =  model_artifact_config.vocab_size
+
+    # Initialize optional parameters
     if request.presence_penalty is not None:
         sampling_params.presence_penalty = request.presence_penalty
     if request.frequency_penalty is not None:
@@ -74,7 +71,9 @@ def _get_sampling_params(
         sampling_params.logprobs = request.logprobs
     if request.response_format and request.response_format.type == "json_object":
         sampling_params.json_schema = request.response_format.response_schema
-    sampling_params.vocab_size = model_artifact_config.vocab_size
+
+    sampling_params.verify()
+
     return sampling_params
 
 

--- a/serve/mlc_serve/engine/sampling_params.py
+++ b/serve/mlc_serve/engine/sampling_params.py
@@ -80,7 +80,7 @@ class SamplingParams:
         if self.logit_bias:
             self.logit_bias_index = list(self.logit_bias.keys())
             self.logit_bias_value = list(self.logit_bias.values())
-        self._verify_args()
+        self.verify()
         if self.temperature < _SAMPLING_EPS:
             # Zero temperature means greedy sampling.
             self.top_p = 1.0
@@ -89,7 +89,7 @@ class SamplingParams:
         if not self.logprobs:
             self.top_logprobs = 0
 
-    def _verify_args(self) -> None:
+    def verify(self) -> None:
         if not -2.0 <= self.presence_penalty <= 2.0:
             raise ValueError(
                 "presence_penalty must be in [-2, 2], got " f"{self.presence_penalty}."

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -60,9 +60,7 @@ class StagingInferenceEngine(ScopedInferenceEngine):
 
         # TODO(@team): This is a temporary solution to expose model config to higher API layer.
         #   Follow-up with the proper solution
-        self.model_artifact_config = get_model_artifact_config(
-            model_module_loader_kwargs["model_artifact_path"]
-        )
+        self.model_artifact_config = model_module_loader_kwargs["model_artifact_config"]
         self.tokenizer = tokenizer_module.tokenizer
         self.conversation_template = tokenizer_module.conversation_template
 

--- a/serve/mlc_serve/model/base.py
+++ b/serve/mlc_serve/model/base.py
@@ -4,6 +4,7 @@ import os
 import json
 import inspect
 
+
 # TODO(@sunggg): consider transition to something like Pydantic
 @dataclass
 class ModelArtifactConfig:
@@ -32,10 +33,12 @@ class ModelArtifactConfig:
             }
         )
 
+
 class AssetNotFound(Exception):
     def __init__(self, asset_path):
         self.asset_path = asset_path
         super().__init__(f"{self.asset_path} should exist. Did you build with `--enable-batching`?")
+
 
 def get_model_artifact_config(model_artifact_path):
     json_object = {"model_artifact_path": model_artifact_path}

--- a/serve/mlc_serve/model/paged_cache_model.py
+++ b/serve/mlc_serve/model/paged_cache_model.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import structlog
 from typing import Sequence, List
 
-from .base import get_model_artifact_config
+from .base import ModelArtifactConfig
 from .paged_cache_manager import CacheManager
 from .tokenizer import HfTokenizerModule, ConversationTemplate, Tokenizer
 from .tvm_model import init_tvm_model
@@ -17,6 +17,7 @@ from ..engine.model_module import (
     TextGenerationResult,
     TextGenerator,
 )
+
 
 LOG = structlog.stdlib.get_logger(__name__)
 
@@ -78,9 +79,8 @@ class PagedCacheModelModule:
         self,
         model_artifact_path: Path,
         engine_config: MLCServeEngineConfig,
+        model_artifact_config: ModelArtifactConfig
     ):
-        model_artifact_config = get_model_artifact_config(model_artifact_path)
-
         # TODO(masahi): Make the model type configurable.
         model, cache_manager = init_tvm_model(model_artifact_config, engine_config)
 

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -22,7 +22,7 @@ def run_server():
     with tempfile.TemporaryDirectory() as temp_dir:
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = temp_dir
 
-        engine = create_mlc_engine(args)
+        engine = create_mlc_engine(args, start_engine=False)
         connector = AsyncEngineConnector(engine)
         app = create_app(connector)
 

--- a/serve/mlc_serve/run.py
+++ b/serve/mlc_serve/run.py
@@ -1,14 +1,10 @@
-import argparse
 import tempfile
 import os
 import uvicorn
 
 from .api import create_app
-from .engine import AsyncEngineConnector, get_engine_config
-from .engine.staging_engine import StagingInferenceEngine
-from .engine.sync_engine import SynchronousInferenceEngine
-from .model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
-from .utils import get_default_mlc_serve_argparser, postproc_mlc_serve_args
+from .engine import AsyncEngineConnector
+from .utils import get_default_mlc_serve_argparser, postproc_mlc_serve_args, create_mlc_engine
 
 
 def parse_args():
@@ -20,52 +16,13 @@ def parse_args():
     return args
 
 
-def create_engine(
-    args: argparse.Namespace,
-):
-    """
-    `model_artifact_path` has the following structure
-    |- compiled artifact (.so)
-    |- `build_config.json`: stores compile-time info, such as `num_shards` and `quantization`.
-    |- params/ : stores weights in mlc format and `ndarray-cache.json`.
-    |            `ndarray-cache.json` is especially important for Disco.
-    |- model/ : stores info from hf model cards such as max context length and tokenizer
-    """
-    # Set the engine config
-    engine_config = get_engine_config(
-        {
-            "use_staging_engine": args.use_staging_engine,
-            "max_num_batched_tokens": args.max_num_batched_tokens,
-            "min_decode_steps": args.min_decode_steps,
-            "max_decode_steps": args.max_decode_steps,
-        }
-    )
-
-    if args.use_staging_engine:
-        return StagingInferenceEngine(
-            tokenizer_module=HfTokenizerModule(args.model_artifact_path),
-            model_module_loader=PagedCacheModelModule,
-            model_module_loader_kwargs={
-                "model_artifact_path": args.model_artifact_path,
-                "engine_config": engine_config,
-            },
-        )
-    else:
-        return SynchronousInferenceEngine(
-            PagedCacheModelModule(
-                model_artifact_path=args.model_artifact_path,
-                engine_config=engine_config,
-            )
-        )
-
-
 def run_server():
     args = parse_args()
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = temp_dir
 
-        engine = create_engine(args)
+        engine = create_mlc_engine(args)
         connector = AsyncEngineConnector(engine)
         app = create_app(connector)
 

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -10,6 +10,7 @@ from mlc_serve.engine import get_engine_config, InferenceEngine
 from mlc_serve.logging_utils import configure_logging
 from mlc_serve.engine.staging_engine import StagingInferenceEngine
 from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
+from mlc_serve.model.base import get_model_artifact_config
 from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
 
 
@@ -55,6 +56,7 @@ def create_mlc_engine(args: argparse.Namespace) -> InferenceEngine:
             "max_decode_steps": args.max_decode_steps,
         }
     )
+    model_artifact_config = get_model_artifact_config(args.model_artifact_path)
 
     engine: InferenceEngine
 
@@ -65,6 +67,7 @@ def create_mlc_engine(args: argparse.Namespace) -> InferenceEngine:
             model_module_loader_kwargs={
                 "model_artifact_path": args.model_artifact_path,
                 "engine_config": engine_config,
+                "model_artifact_config": model_artifact_config
             },
         )
         engine.start()
@@ -73,6 +76,8 @@ def create_mlc_engine(args: argparse.Namespace) -> InferenceEngine:
             PagedCacheModelModule(
                 model_artifact_path=args.model_artifact_path,
                 engine_config=engine_config,
+                model_artifact_config=model_artifact_config
             )
         )
+
     return engine

--- a/serve/mlc_serve/utils.py
+++ b/serve/mlc_serve/utils.py
@@ -47,7 +47,7 @@ def postproc_mlc_serve_args(args):
     random.seed(args.seed)
 
 
-def create_mlc_engine(args: argparse.Namespace) -> InferenceEngine:
+def create_mlc_engine(args: argparse.Namespace, start_engine=True) -> InferenceEngine:
     engine_config = get_engine_config(
         {
             "use_staging_engine": args.use_staging_engine,
@@ -70,7 +70,9 @@ def create_mlc_engine(args: argparse.Namespace) -> InferenceEngine:
                 "model_artifact_config": model_artifact_config
             },
         )
-        engine.start()
+
+        if start_engine:
+            engine.start()
     else:
         engine = SynchronousInferenceEngine(
             PagedCacheModelModule(

--- a/serve/tests/test_engine.py
+++ b/serve/tests/test_engine.py
@@ -8,41 +8,16 @@ from mlc_serve.engine import (
     DebugOptions,
     SamplingParams,
     StoppingCriteria,
-    get_engine_config,
 )
-from mlc_serve.engine.staging_engine import StagingInferenceEngine
-from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
-from mlc_serve.model.paged_cache_model import HfTokenizerModule, PagedCacheModelModule
-from mlc_serve.utils import get_default_mlc_serve_argparser, postproc_mlc_serve_args
+from mlc_serve.utils import (
+    get_default_mlc_serve_argparser,
+    postproc_mlc_serve_args,
+    create_mlc_engine,
+)
 
 
 def _test(args: argparse.Namespace):
-    engine_config = get_engine_config(
-        {
-            "use_staging_engine": args.use_staging_engine,
-            "max_num_batched_tokens": args.max_num_batched_tokens,
-            "min_decode_steps": args.min_decode_steps,
-            "max_decode_steps": args.max_decode_steps,
-        }
-    )
-
-    if args.use_staging_engine:
-        engine = StagingInferenceEngine(
-            tokenizer_module=HfTokenizerModule(args.model_artifact_path),
-            model_module_loader=PagedCacheModelModule,
-            model_module_loader_kwargs={
-                "model_artifact_path": args.model_artifact_path,
-                "engine_config": engine_config,
-            },
-        )
-        engine.start()
-    else:
-        engine = SynchronousInferenceEngine(
-            PagedCacheModelModule(
-                model_artifact_path=args.model_artifact_path,
-                engine_config=engine_config,
-            )
-        )
+    engine = create_mlc_engine(args)
 
     sampling_params_greedy = SamplingParams(
         temperature=0.0,

--- a/serve/tests/unittest/test_sync_engine.py
+++ b/serve/tests/unittest/test_sync_engine.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-
+from typing import Optional
 from mlc_serve.engine import (
     ChatMessage,
     FinishReason,
@@ -8,24 +7,9 @@ from mlc_serve.engine import (
     RequestOutput,
     SamplingParams,
     StoppingCriteria,
-    get_engine_config
 )
-from mlc_serve.model.base import ModelArtifactConfig
-from mlc_serve.engine.model_module import (
-    DecodeRequest,
-    KVCache,
-    PrefillRequest,
-    SequenceId,
-    TextGenerationResult,
-)
-
 from mlc_serve.engine.sync_engine import SynchronousInferenceEngine
-from mlc_serve.engine.staging_engine import StagingInferenceEngine
-
-from mlc_serve.model.dummy_model import (
-    DummyModelModule,
-    DummyTokenizerModule,
-)
+from mlc_serve.model.dummy_model import DummyModelModule
 
 
 def create_messages(prompt) -> list[ChatMessage]:


### PR DESCRIPTION
As of https://github.com/octoml/mlc-llm/pull/192, `StagingEngine` needs to have `model_artifact_config`, which is created in the worker process. Creating the config in the constructor again, via `get_model_artifact_config`, is problematic for PT models since there is no build artifact for PT models (hence `get_model_artifact_config` cannot be used). 

This PR does a refactor around how `ModelArtifactConfig` is constructed. Rather than creating it inside `PagedCacheModel`, we are now creating it at the beginning of the engine initialization. So the created config can be passed to all of `StagingEngine`, `StagingEngineWorker`, and `SyncEngine`.  

Note that the same update needs to be applied to ollm in the next revision bump.

It also fixes the issue of `SamplingParams` not being verified correctly due to how it is initialized.

@sunggg @yelite 