### PR TITLE
Fix QKV weight sharding for gemma

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -646,10 +646,7 @@ def mod_transform_before_build(
             num_key_value_heads = config.get_num_key_value_heads()
             num_query_heads = config.num_attention_heads // args.num_shards
             hidden_size = config.hidden_size // args.num_shards
-            if hasattr(config, "head_dim"):
-                head_dim = config.head_dim
-            else:
-                head_dim = hidden_size // num_query_heads
+            head_dim = config.get_head_dim()
             # pylint: disable=no-value-for-parameter
             mod = fuse_split_rotary_embedding(
                 num_query_heads,

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -32,7 +32,7 @@ def create_metadata_func(
 def _get_shard_strategies(
     model_config, num_shards: int, param_shape_is_already_sharded: bool
 ) -> Dict[str, tvm.tir.PrimFunc]:
-    head_dim = model_config.hidden_size // model_config.num_attention_heads
+    head_dim = model_config.get_head_dim()
     q_heads = model_config.num_attention_heads
     kv_heads = model_config.get_num_key_value_heads()
 

--- a/mlc_llm/relax_model/llama_batched_vllm.py
+++ b/mlc_llm/relax_model/llama_batched_vllm.py
@@ -569,11 +569,7 @@ class LlamaForCausalLM(nn.Module):
             self.lm_head = Linear(config.hidden_size, vocab_size_var, dtype=config.dtype, bias=False)
 
         ############ Rotary embedding constants ############
-        if hasattr(config, "head_dim"):
-            head_dim = config.head_dim
-        else:
-            assert config.hidden_size % config.num_attention_heads == 0
-            head_dim = config.hidden_size // config.num_attention_heads
+        head_dim = config.get_head_dim()
 
         # Set the cached sin/cos to the maximum of 2048 and max seq len.
         # This will be eliminated further with online rotary embedding calculation.
@@ -722,10 +718,7 @@ def get_inputs(
 
         num_key_value_heads = config.get_num_key_value_heads() // config.num_shards
 
-        if hasattr(config, "head_dim"):
-            head_size = config.head_dim
-        else:
-            head_size = config.hidden_size // config.num_attention_heads
+        head_size = config.get_head_dim()
 
         if kv_type == KVCacheType.VLLM:
             block_size = VllmAttention.block_size


### PR DESCRIPTION
This fixes multi-gpu inference for gemma. The sharding function was assuming `head_dim = model_config.hidden_size // model_config.num_attention_heads`, which is incorrect for gemma.

@sunggg @Lunderberg 