### PR TITLE
Protect against errors raised when adding a request to the engine

### DIFF
--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -150,10 +150,7 @@ class AsyncEngineConnector:
         queue = asyncio.Queue()
         self.result_queues[request.request_id] = queue
 
-        try:
-            await asyncio.to_thread(self.engine.add, [request])
-        except TextGenerationError as e:
-            raise asyncio.CancelledError(e)
+        await asyncio.to_thread(self.engine.add, [request])
 
         return queue
 

--- a/serve/mlc_serve/engine/async_connector.py
+++ b/serve/mlc_serve/engine/async_connector.py
@@ -150,7 +150,10 @@ class AsyncEngineConnector:
         queue = asyncio.Queue()
         self.result_queues[request.request_id] = queue
 
-        await asyncio.to_thread(self.engine.add, [request])
+        try:
+            await asyncio.to_thread(self.engine.add, [request])
+        except TextGenerationError as e:
+            raise asyncio.CancelledError(e)
 
         return queue
 

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -131,6 +131,7 @@ class StagingInferenceEngine(ScopedInferenceEngine):
                 )
                 new_request_states.append(state)
             except Exception as e:
+                LOG.warn("Failed to add a request", request_id=req.request_id)
                 with self.requests_to_be_cancelled_lock:
                     self.requests_to_be_cancelled[req.request_id] = str(e)
 

--- a/serve/mlc_serve/engine/staging_engine.py
+++ b/serve/mlc_serve/engine/staging_engine.py
@@ -57,6 +57,9 @@ class StagingInferenceEngine(ScopedInferenceEngine):
         self.next_generation_output = None
         self.requests_lock = Lock()
         self.requests = dict[RequestId, RequestState]()
+        self.requests_to_be_cancelled_lock = Lock()
+        # Error message for each request that fails to be added to the engine
+        self.requests_to_be_cancelled = dict[RequestId, str]()
 
         # TODO(@team): This is a temporary solution to expose model config to higher API layer.
         #   Follow-up with the proper solution
@@ -119,13 +122,17 @@ class StagingInferenceEngine(ScopedInferenceEngine):
                 assert isinstance(req.stopping_criteria.stop_sequences, list)
 
             # If the request violates the tokenization, this returns None, so skip.
-            state = get_new_request_state(
-                req,
-                self.conversation_template,
-                self.tokenizer,
-                self.model_artifact_config.vocab_size,
-            )
-            new_request_states.append(state)
+            try:
+                state = get_new_request_state(
+                    req,
+                    self.conversation_template,
+                    self.tokenizer,
+                    self.model_artifact_config.vocab_size,
+                )
+                new_request_states.append(state)
+            except Exception as e:
+                with self.requests_to_be_cancelled_lock:
+                    self.requests_to_be_cancelled[req.request_id] = str(e)
 
         self.command_queue.put(AddRequestsCommand(request_states=new_request_states))
 
@@ -171,11 +178,25 @@ class StagingInferenceEngine(ScopedInferenceEngine):
             has_pending_requests=self.has_pending_requests(),
         )
 
+        outputs = list[RequestOutput]()
+
+        with self.requests_to_be_cancelled_lock:
+            if len(self.requests_to_be_cancelled) > 0:
+                for req_id, err_msg in self.requests_to_be_cancelled.items():
+                    outputs.append(
+                        RequestOutput(
+                            req_id,
+                            sequences=[],
+                            error=err_msg,
+                        )
+                    )
+                self.requests_to_be_cancelled.clear()
+
         if not self._is_ready_to_serve():
             raise RuntimeError("GenerationLoopWorker process is not running")
 
         if not self.has_pending_requests():
-            return InferenceStepResult([])
+            return InferenceStepResult(outputs)
 
         if self.next_generation_output is None:
             generation_output = self.result_queue.get()
@@ -187,8 +208,6 @@ class StagingInferenceEngine(ScopedInferenceEngine):
             raise RuntimeError(
                 f"Error from GenerationLoopWorker process: {generation_output.error}"
             ) from generation_output.error
-
-        outputs = list[RequestOutput]()
 
         with self.requests_lock:
             LOG.debug(


### PR DESCRIPTION
Previously, when an exception is raised at `get_new_request_state(...)` due to a malformed request, the server just dies. 

An example of such error
```
  File "/home/masahi/projects/dev/mlc-llm/serve/mlc_serve/engine/staging_engine.py", line 122, in add                              
    state = get_new_request_state(
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masahi/projects/dev/mlc-llm/serve/mlc_serve/engine/engine_common.py", line 57, in get_new_request_state
    prompt = conversation_template.apply(request.messages)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masahi/projects/dev/mlc-llm/serve/mlc_serve/model/tokenizer.py", line 41, in apply
    return self._tokenizer.apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masahi/miniconda3/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 1745, in apply_chat_template
    rendered = compiled_template.render(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masahi/miniconda3/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/home/masahi/miniconda3/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 1, in top-level template code
  File "/home/masahi/miniconda3/lib/python3.11/site-packages/jinja2/sandbox.py", line 393, in call
    return __context.call(__obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/masahi/miniconda3/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 1790, in raise_exception
    raise TemplateError(message)
jinja2.exceptions.TemplateError: Conversation roles must alternate user/assistant/user/assistant/...
```

And a repro script
```
import os
import openai

def jsonmode(endpoint, model, prompt, schema):
    client = openai.OpenAI(base_url=f"{endpoint}/v1", api_key="xxxxx")
    response_format={"type": "json_object", "schema": schema}
    chat_completion = client.chat.completions.create(
        model=model,
        messages=[
            {
                "role": "system",
                "content": "You are a helpful assistant.",
            },
            {
                "role": "user",
                "content": prompt,
            },
        ],
        temperature=0,
        max_tokens=512,
        response_format=response_format,
    )

    jsonstr = chat_completion.choices[0].message.content
    return jsonstr


schema_without_circular_dependency = {
    "$defs": {
        "Person": {"type": "object", "properties": {"name": {"type": "string"}}},
        "Family": {
            "type": "object",
            "properties": {
                "last_name": {"type": "string"},
                "members": {"type": "array", "items": {"$ref": "#/$defs/Person"}},
            },
        },
    },
}

endpoint = "http://localhost:9000"
model = "mistral-7b-instruct"

prompt = "The Doe family has members John and Jane"
winner = jsonmode(endpoint, model, prompt, schema_without_circular_dependency)
print(winner)
```

@yelite @elvin-n