### PR TITLE
[FP8] Add shard strategy to from_linear for PTQ.

### DIFF
--- a/python/mlc_chat/quantization/per_tensor_quantization.py
+++ b/python/mlc_chat/quantization/per_tensor_quantization.py
@@ -337,8 +337,7 @@ class PerTensorQuantizeLinear(nn.Module):
         if "shard_strategy" in src.weight.attrs:
             shard = src.weight.attrs["shard_strategy"]
             apply_sharding(shard, f"{shard.name}_q_weight", quantized_linear.q_weight)
-            if not config.no_scale:
-                apply_sharding(shard, f"{shard.name}_q_scale", quantized_linear.q_scale)
+            # scale doesn't need to be sharded since it's the same for all shards
         return quantized_linear
 
     def forward(self, x: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name

--- a/python/mlc_chat/quantization/per_tensor_quantization.py
+++ b/python/mlc_chat/quantization/per_tensor_quantization.py
@@ -333,6 +333,12 @@ class PerTensorQuantizeLinear(nn.Module):
         )
         if quantized_linear.bias is not None:
             quantized_linear.bias.attrs = src.bias.attrs
+
+        if "shard_strategy" in src.weight.attrs:
+            shard = src.weight.attrs["shard_strategy"]
+            apply_sharding(shard, f"{shard.name}_q_weight", quantized_linear.q_weight)
+            if not config.no_scale:
+                apply_sharding(shard, f"{shard.name}_q_scale", quantized_linear.q_scale)
         return quantized_linear
 
     def forward(self, x: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name


### PR DESCRIPTION
We missed this in #232. Fixes param loader error
```
2024-03-19 16:23:37 [info     ] Loading parameters from dist/mixtral-8x7b-instruct-v0.1-fp8_e4m3_e5m2_max-vllm-2gpu. [mlc_serve.model.tvm_model] func_name=get_tvm_model lineno=66 pathname=/home/csullivan/scratch/ollm-2/mlc-serve/mlc_serve/model/tvm_model.py process=146792
[16:23:43] /home/csullivan/scratch/ollm-2/deps/tvm/src/runtime/disco/loader.cc:464: [Worker #0] Loading model to device: cuda:0
[16:23:43] /home/csullivan/scratch/ollm-2/deps/tvm/src/runtime/disco/loader.cc:464: [Worker #1] Loading model to device: cuda:1
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/csullivan/scratch/ollm-2/deps/mlc-llm/python/mlc_chat/cli/worker.py", line 51, in <module>
    main()
  File "/home/csullivan/scratch/ollm-2/deps/mlc-llm/python/mlc_chat/cli/worker.py", line 46, in main
    worker_func(worker_id, num_workers, reader, writer)
  File "/home/csullivan/scratch/ollm-2/deps/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 239, in __call__
    raise_last_ffi_error()
  File "/home/csullivan/scratch/ollm-2/deps/tvm/python/tvm/_ffi/base.py", line 481, in raise_last_ffi_error
    raise py_err
tvm._ffi.base.TVMError: _Map_base: :at
terminate called after throwing an instance of 'std::out_of_range'
  what():  _Map_base::at

```