### PR TITLE
[FP8] Fix invalid reinterpret during dequantize

### DIFF
--- a/python/mlc_chat/quantization/utils.py
+++ b/python/mlc_chat/quantization/utils.py
@@ -63,7 +63,8 @@ def convert_uint_packed_fp8_to_float(  # pylint: disable=too-many-arguments
     if ft_reorder:
         raise NotImplementedError()
     assert quant_dtype in ["e4m3_float8", "e5m2_float8"]
-    tir_bin_mask = tir.const((1 << bits) - 1, storage_dtype)
+    elem_storage_dtype = f"uint{bits}"
+    tir_bin_mask = tir.const((1 << bits) - 1, elem_storage_dtype)
     if out_shape is None:
         out_shape = weight.shape
         out_shape[axis] *= num_elem_per_storage
@@ -76,7 +77,7 @@ def convert_uint_packed_fp8_to_float(  # pylint: disable=too-many-arguments
                 tir.shift_right(
                     weight(*idx[:axis], idx[axis] // num_elem_per_storage, *idx[axis + 1 :]),
                     ((idx[axis] % num_elem_per_storage) * bits).astype(storage_dtype),
-                ),
+                ).astype(elem_storage_dtype),
                 tir_bin_mask,
             ),
         ).astype(model_dtype),


### PR DESCRIPTION
This reinterpret from uint32 to float8 relies on the fact that float8 is stored in the first byte of uint32, this behavior is unreliable when it's vectorized. cc @csullivan 

I'll also add a check to codegen to prohibit this cast