### PR TITLE
[SLM] Add ShardScalar tensor_parallel sharding strategy

### DIFF
--- a/python/mlc_chat/quantization/fp8_quantization.py
+++ b/python/mlc_chat/quantization/fp8_quantization.py
@@ -351,7 +351,11 @@ class MixtralExpertsFP8(
         if "shard_strategy" in src.weight.attrs:
             shard = src.weight.attrs["shard_strategy"]
             apply_sharding(shard, f"{shard.name}_q_weight", quantized_mistral_experts.q_weight)
-            # scale doesn't need to be sharded since it's the same for all shards
+            apply_sharding(
+                tp.ShardScalar(name=shard.name),
+                f"{shard.name}_q_scale",
+                quantized_mistral_experts.q_scale,
+            )
 
         return quantized_mistral_experts
 

--- a/python/mlc_chat/quantization/per_tensor_quantization.py
+++ b/python/mlc_chat/quantization/per_tensor_quantization.py
@@ -332,7 +332,9 @@ class PerTensorQuantizeLinear(nn.Module):
         if "shard_strategy" in src.weight.attrs:
             shard = src.weight.attrs["shard_strategy"]
             apply_sharding(shard, f"{shard.name}_q_weight", quantized_linear.q_weight)
-            # scale doesn't need to be sharded since it's the same for all shards
+            apply_sharding(
+                tp.ShardScalar(name=shard.name), f"{shard.name}_q_scale", quantized_linear.q_scale
+            )
         return quantized_linear
 
     def forward(self, x: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name

--- a/python/mlc_chat/quantization/per_tensor_quantization.py
+++ b/python/mlc_chat/quantization/per_tensor_quantization.py
@@ -14,7 +14,7 @@ from tvm.target import Target
 from mlc_chat.loader import QuantizeMapping
 from mlc_chat.nn import MixtralExperts
 from mlc_chat.support import logging
-
+from mlc_chat.support import tensor_parallel as tp
 
 from .utils import (
     is_final_fc,

--- a/python/mlc_chat/quantization/utils.py
+++ b/python/mlc_chat/quantization/utils.py
@@ -119,5 +119,9 @@ def apply_sharding(shard, name: str, weight: nn.Parameter):
             dim=shard.dim,
             segs=shard.segs,
         )
+    elif isinstance(shard, tp.ShardScalar):
+        weight.attrs["shard_strategy"] = tp.ShardScalar(
+            name=name,
+        )
     else:
         raise NotImplementedError(f"Unknowing sharding strategy: {shard}")

--- a/python/mlc_chat/support/preshard.py
+++ b/python/mlc_chat/support/preshard.py
@@ -24,31 +24,15 @@ def _update_quantize_map(
     if mlc_name in quantize_map.param_map:
         # the parameter is quantized
         quantized_params = quantize_map.param_map[mlc_name]
-        quantized_params_to_shard = []
-        for param_name in quantized_params:
-            if "shard_strategy" in named_params[param_name].attrs:
-                quantized_params_to_shard.append(param_name)
-
-        param_names = quantized_params_to_shard
+        param_names = quantized_params
         quantize_func = quantize_map.map_func[mlc_name]
 
-
         for worker_id in range(tensor_parallel_shards):
-            if quantized_params_to_shard:
-                sharded_mlc_name = _sharded_param_name(mlc_name, worker_id)
-                quantize_map.param_map[sharded_mlc_name] = [
-                    _sharded_param_name(param_name, worker_id) for param_name in quantized_params_to_shard
-                ]
-                quantize_map.map_func[sharded_mlc_name] = quantize_func
-
-        # Add non-sharded quantized params to the param_map entry for the last shard.
-        # Note that in the current implementation, the quantize_map.map_func is run
-        # one time per shard which means these non-sharded params will be recomputed
-        # multiple times (once per shard) even though their values are equivalent for
-        # each shard.
-        for param_name in quantized_params:
-            if param_name not in quantized_params_to_shard:
-                quantize_map.param_map[sharded_mlc_name].append(param_name)
+            sharded_mlc_name = _sharded_param_name(mlc_name, worker_id)
+            quantize_map.param_map[sharded_mlc_name] = [
+                _sharded_param_name(param_name, worker_id) for param_name in quantized_params
+            ]
+            quantize_map.map_func[sharded_mlc_name] = quantize_func
 
     for param_name in param_names:
         param = named_params.pop(param_name)

--- a/python/mlc_chat/support/tensor_parallel.py
+++ b/python/mlc_chat/support/tensor_parallel.py
@@ -75,6 +75,27 @@ class ShardSingleDim:
             "out_dtype": weight.dtype,
         }
 
+@dataclasses.dataclass
+class ShardScalar:
+    """
+    Shard a scalar param into multiple distinct scalars, one for each shard.
+
+
+    Parameters
+    ----------
+    name : str
+        The name of the shard func
+    """
+
+    name: str
+    def gen_shard_info(self, shards: int, weight: nn.Tensor) -> Dict[str, Any]:
+        """Generate shard info for this sharding strategy."""
+        return {
+            "func_name": self.name,
+            "out_shape": (shards, *weight.shape),
+            "out_dtype": weight.dtype,
+        }
+
 
 @contextmanager
 def shard_bias(linear: nn.Linear, tensor_parallel_shards: int):


### PR DESCRIPTION
@vinx13 this the main numerical bug discovered. We need to handle sharding of the scalar quantization scale factors for the weights by having one for each shard. The main issue is that SLM quantizes each shard separately which was not the expected behavior when designing the per tensor quantization. 