### PR TITLE
[FP8] Add config to enable/disable linear quantization.

### DIFF
--- a/python/mlc_chat/quantization/per_tensor_quantization.py
+++ b/python/mlc_chat/quantization/per_tensor_quantization.py
@@ -35,6 +35,7 @@ class PerTensorQuantize:
     storage_dtype: Literal["uint32"]
     model_dtype: Literal["float16"]
     quantize_embedding: bool = True
+    quantize_linear: bool = True
     quantize_final_fc: bool = True
 
     num_elem_per_storage: int = 0
@@ -104,8 +105,10 @@ class PerTensorQuantize:
                         f"{name}.q_weight",
                     ]
                 )
-                if isinstance(node, nn.Linear) and (
-                    not is_final_fc(name) or self.config.quantize_final_fc
+                if (
+                    isinstance(node, nn.Linear)
+                    and self.config.quantize_linear
+                    and (not is_final_fc(name) or self.config.quantize_final_fc)
                 ):
                     self.quant_map.param_map[weight_name] = param_names
                     self.quant_map.map_func[weight_name] = self.config.quantize_weight

--- a/python/mlc_chat/quantization/quantization.py
+++ b/python/mlc_chat/quantization/quantization.py
@@ -172,6 +172,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         model_dtype="float16",
         no_scale=True,
         quantize_embedding=False,
+        quantize_linear=False,
     ),
     "fp8_e4m3_e5m2_max": PerTensorQuantize(
         name="fp8_e4m3_e5m2_max",
@@ -182,6 +183,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         model_dtype="float16",
         no_scale=True,
         quantize_embedding=False,
+        quantize_linear=False,
     ),
     "fp8_e4m3_e4m3_max_calibration": PerTensorQuantize(
         name="fp8_e4m3_e4m3_max_calibration",
@@ -191,6 +193,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         storage_dtype="uint8",
         model_dtype="float16",
         quantize_embedding=False,
+        quantize_linear=False,
     ),
     "fp8_e4m3_e4m3_max": PerTensorQuantize(
         name="fp8_e4m3_e4m3_max",
@@ -200,6 +203,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         storage_dtype="uint32",
         model_dtype="float16",
         quantize_embedding=False,
+        quantize_linear=False,
     ),
     "fp16_max_calibration": PerTensorQuantize(
         name="fp16_max_calibration",
@@ -209,6 +213,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         storage_dtype="float16",
         model_dtype="float16",
         quantize_embedding=False,
+        quantize_linear=False,
         no_scale=True,
     ),
 }


### PR DESCRIPTION
* Disable linear quant for max calibration as there is currently no FP8 compute written for linear.