### PR TITLE
[FP8] Modify PTQ dequantize function for cuBLAS offloading

### DIFF
--- a/python/mlc_llm/quantization/fp8_quantization.py
+++ b/python/mlc_llm/quantization/fp8_quantization.py
@@ -576,11 +576,12 @@ class PTQLinearFP8(ptq.PerTensorQuantizeLinear):  # pylint: disable=too-many-ins
             total_scale = 1.0
         else:
             if self.runtime == "max" and self.weight_dtype == "e4m3_float8":
-                total_scale = local_scale * self.q_scale
+                local_scale = nn.op.astype(local_scale, dtype="float32")
+                q_scale = nn.op.astype(self.q_scale, dtype="float32")
+                total_scale = local_scale * q_scale
             else:
                 # for calibration, q_scale is already used to dequantize the weights
-                total_scale = local_scale
-            total_scale = nn.op.astype(total_scale, dtype="float32")
+                total_scale = nn.op.astype(local_scale, dtype="float32")
 
         x *= total_scale
 


### PR DESCRIPTION
This commit modifies PTQ dequantize function to enable offloading to cuBLAS.

Before modification:
```
  matmul_out = R.linear
  scale = R.multiply(a_scale, w_scale)
  scale_fp32 = R.cast(scale, "float32")
  out_fp32 = R.multiply(matmul_out, scale_fp32)
  out_fp16 = R.cast(out_fp32, "float16")
```

After modification:
```
  matmul_out = R.linear
  a_scale = R.cast(a_scale, "float32")
  w_scale = R.cast(w_scale, "float32")
  scale = R.multiply(a_scale, w_scale)
  out_fp32 = R.multiply(matmul_out, scale)
  out_fp16 = R.cast(out_fp32, "float16")
```