### PR TITLE
Use enum for quant types instead of strings

### DIFF
--- a/python/mlc_llm/quantization/__init__.py
+++ b/python/mlc_llm/quantization/__init__.py
@@ -4,5 +4,5 @@ from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .per_tensor_quantization import PerTensorQuantize
 from .no_quantization import NoQuantize
-from .quantization import QUANTIZATION, Quantization
+from .quantization import QUANTIZATION, Quantization, MLCQuantization
 from .smooth_quantization import SmoothQuantize

--- a/python/mlc_llm/quantization/quantization.py
+++ b/python/mlc_llm/quantization/quantization.py
@@ -1,5 +1,6 @@
 """A centralized registry of all existing quantization methods and their configurations."""
 from typing import Any, Dict
+from enum import Enum
 
 from .awq_quantization import AWQQuantize
 from .ft_quantization import FTQuantize
@@ -9,6 +10,7 @@ from .per_tensor_quantization import PerTensorQuantize
 from .smooth_quantization import SmoothQuantize
 
 Quantization = Any
+# TODO(jmcmahan): make this an abstract class + add `req_calibration` (default False) to better detect calibration requirement
 """Quantization is an object that represents an quantization algorithm. It is required to
 have the following fields:
 
@@ -27,19 +29,45 @@ It is also required to have the following method:
         ...
 """
 
+class MLCQuantization(str, Enum):
+    q0f16 = "q0f16"
+    q0f32 = "q0f32"
+    q3f16_0 = "q3f16_0"
+    q3f16_1 = "q3f16_1"
+    q4f16_0 = "q4f16_0"
+    q4f16_1 = "q4f16_1"
+    q4f32_1 = "q4f32_1"
+    q4f16_2 = "q4f16_2"
+    q4f16_autoawq = "q4f16_autoawq"
+    q4f16_ft = "q4f16_ft"
+    fp8_e4m3_e4m3_max_calibration = "fp8_e4m3_e4m3_max_calibration"
+    fp8_e4m3_e4m3_max = "fp8_e4m3_e4m3_max"
+    ptq_e4m3_e4m3_max_calibration = "ptq_e4m3_e4m3_max_calibration"
+    ptq_e4m3_e4m3_max = "ptq_e4m3_e4m3_max"
+    smq_q8i8f16_0 = "smq_q8i8f16_0"
+    smq_q8i8f16_1 = "smq_q8i8f16_1"
+    smq_q8i8f16_2 = "smq_q8i8f16_2"
+    smq_e4m3_float8_0 = "smq_e4m3_float8_0"
+    smq_e4m3_float8_1 = "smq_e4m3_float8_1"
+    smq_e4m3_float8_2 = "smq_e4m3_float8_2"
+    smq_e5m2_float8_0 = "smq_e5m2_float8_0"
+    smq_e5m2_float8_1 = "smq_e5m2_float8_1"
+    smq_e5m2_float8_2 = "smq_e5m2_float8_2"
+    fp16_max_calibration = "fp16_max_calibration"    
+
 QUANTIZATION: Dict[str, Quantization] = {
-    "q0f16": NoQuantize(
-        name="q0f16",
+    MLCQuantization.q0f16: NoQuantize(
+        name=MLCQuantization.q0f16,
         kind="no-quant",
         model_dtype="float16",
     ),
-    "q0f32": NoQuantize(
-        name="q0f32",
+    MLCQuantization.q0f32: NoQuantize(
+        name=MLCQuantization.q0f32,
         kind="no-quant",
         model_dtype="float32",
     ),
-    "q3f16_0": GroupQuantize(
-        name="q3f16_0",
+    MLCQuantization.q3f16_0: GroupQuantize(
+        name=MLCQuantization.q3f16_0,
         kind="group-quant",
         group_size=40,
         quantize_dtype="int3",
@@ -49,8 +77,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=True,
         quantize_final_fc=True,
     ),
-    "q3f16_1": GroupQuantize(
-        name="q3f16_1",
+    MLCQuantization.q3f16_1: GroupQuantize(
+        name=MLCQuantization.q3f16_1,
         kind="group-quant",
         group_size=40,
         quantize_dtype="int3",
@@ -60,8 +88,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=True,
         quantize_final_fc=True,
     ),
-    "q4f16_0": GroupQuantize(
-        name="q4f16_0",
+    MLCQuantization.q4f16_0: GroupQuantize(
+        name=MLCQuantization.q4f16_0,
         kind="group-quant",
         group_size=32,
         quantize_dtype="int4",
@@ -71,8 +99,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=True,
         quantize_final_fc=True,
     ),
-    "q4f16_1": GroupQuantize(
-        name="q4f16_1",
+    MLCQuantization.q4f16_1: GroupQuantize(
+        name=MLCQuantization.q4f16_1,
         kind="group-quant",
         group_size=32,
         quantize_dtype="int4",
@@ -82,8 +110,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=True,
         quantize_final_fc=True,
     ),
-    "q4f32_1": GroupQuantize(
-        name="q4f32_1",
+    MLCQuantization.q4f32_1: GroupQuantize(
+        name=MLCQuantization.q4f32_1,
         kind="group-quant",
         group_size=32,
         quantize_dtype="int4",
@@ -93,8 +121,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=True,
         quantize_final_fc=True,
     ),
-    "q4f16_2": GroupQuantize(
-        name="q4f16_2",
+    MLCQuantization.q4f16_2: GroupQuantize(
+        name=MLCQuantization.q4f16_2,
         kind="group-quant",
         group_size=32,
         quantize_dtype="int4",
@@ -104,23 +132,23 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=False,
         quantize_final_fc=False,
     ),
-    "q4f16_autoawq": AWQQuantize(
-        name="q4f16_autoawq",
+    MLCQuantization.q4f16_autoawq: AWQQuantize(
+        name=MLCQuantization.q4f16_autoawq,
         kind="awq",
         group_size=128,
         quantize_dtype="int4",
         storage_dtype="uint32",
         model_dtype="float16",
     ),
-    "q4f16_ft": FTQuantize(
-        name="q4f16_ft",
+    MLCQuantization.q4f16_ft: FTQuantize(
+        name=MLCQuantization.q4f16_ft,
         kind="ft-quant",
         quantize_dtype="int4",
         storage_dtype="int8",
         model_dtype="float16",
     ),
-    "fp8_e4m3_e4m3_max_calibration": PerTensorQuantize(
-        name="fp8_e4m3_e4m3_max_calibration",
+    MLCQuantization.fp8_e4m3_e4m3_max_calibration: PerTensorQuantize(
+        name=MLCQuantization.fp8_e4m3_e4m3_max_calibration,
         kind="per-tensor-quant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -129,8 +157,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=False,
         quantize_linear=False,
     ),
-    "fp8_e4m3_e4m3_max": PerTensorQuantize(
-        name="fp8_e4m3_e4m3_max",
+    MLCQuantization.fp8_e4m3_e4m3_max: PerTensorQuantize(
+        name=MLCQuantization.fp8_e4m3_e4m3_max,
         kind="per-tensor-quant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -139,8 +167,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=False,
         quantize_linear=False,
     ),
-    "ptq_e4m3_e4m3_max_calibration": PerTensorQuantize(
-        name="ptq_e4m3_e4m3_max_calibration",
+    MLCQuantization.ptq_e4m3_e4m3_max_calibration: PerTensorQuantize(
+        name=MLCQuantization.ptq_e4m3_e4m3_max_calibration,
         kind="per-tensor-quant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -152,8 +180,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         # to enable lm_head quantization for TP > 1
         quantize_final_fc=False,
     ),
-    "ptq_e4m3_e4m3_max": PerTensorQuantize(
-        name="ptq_e4m3_e4m3_max",
+    MLCQuantization.ptq_e4m3_e4m3_max: PerTensorQuantize(
+        name=MLCQuantization.ptq_e4m3_e4m3_max,
         kind="per-tensor-quant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -163,8 +191,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_linear=True,
         quantize_final_fc=False,
     ),
-    "smq_q8i8f16_0": SmoothQuantize(
-        name="smq_q8i8f16_0",
+    MLCQuantization.smq_q8i8f16_0: SmoothQuantize(
+        name=MLCQuantization.smq_q8i8f16_0,
         kind="smoothquant",
         activation_dtype="int8",
         weight_dtype="int8",
@@ -172,8 +200,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="int32",
         model_dtype="float16",
     ),
-    "smq_q8i8f16_1": SmoothQuantize(
-        name="smq_q8i8f16_1",
+    MLCQuantization.smq_q8i8f16_1: SmoothQuantize(
+        name=MLCQuantization.smq_q8i8f16_1,
         kind="smoothquant",
         activation_dtype="int8",
         weight_dtype="int8",
@@ -181,8 +209,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="int32",
         model_dtype="float16",
     ),
-    "smq_q8i8f16_2": SmoothQuantize(
-        name="smq_q8i8f16_2",
+    MLCQuantization.smq_q8i8f16_2: SmoothQuantize(
+        name=MLCQuantization.smq_q8i8f16_2,
         kind="smoothquant",
         activation_dtype="int8",
         weight_dtype="int8",
@@ -190,8 +218,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="int32",
         model_dtype="float16",
     ),
-    "smq_e4m3_float8_0": SmoothQuantize(
-        name="smq_e4m3_float8_0",
+    MLCQuantization.smq_e4m3_float8_0: SmoothQuantize(
+        name=MLCQuantization.smq_e4m3_float8_0,
         kind="smoothquant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -199,8 +227,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "smq_e4m3_float8_1": SmoothQuantize(
-        name="smq_e4m3_float8_1",
+    MLCQuantization.smq_e4m3_float8_1: SmoothQuantize(
+        name=MLCQuantization.smq_e4m3_float8_1,
         kind="smoothquant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -208,8 +236,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "smq_e4m3_float8_2": SmoothQuantize(
-        name="smq_e4m3_float8_2",
+    MLCQuantization.smq_e4m3_float8_2: SmoothQuantize(
+        name=MLCQuantization.smq_e4m3_float8_2,
         kind="smoothquant",
         activation_dtype="e4m3_float8",
         weight_dtype="e4m3_float8",
@@ -217,8 +245,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "smq_e5m2_float8_0": SmoothQuantize(
-        name="smq_e5m2_float8_0",
+    MLCQuantization.smq_e5m2_float8_0: SmoothQuantize(
+        name=MLCQuantization.smq_e5m2_float8_0,
         kind="smoothquant",
         activation_dtype="e5m2_float8",
         weight_dtype="e5m2_float8",
@@ -226,8 +254,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "smq_e5m2_float8_1": SmoothQuantize(
-        name="smq_e5m2_float8_1",
+    MLCQuantization.smq_e5m2_float8_1: SmoothQuantize(
+        name=MLCQuantization.smq_e5m2_float8_1,
         kind="smoothquant",
         activation_dtype="e5m2_float8",
         weight_dtype="e5m2_float8",
@@ -235,8 +263,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "smq_e5m2_float8_2": SmoothQuantize(
-        name="smq_e5m2_float8_2",
+    MLCQuantization.smq_e5m2_float8_2: SmoothQuantize(
+        name=MLCQuantization.smq_e5m2_float8_2,
         kind="smoothquant",
         activation_dtype="e5m2_float8",
         weight_dtype="e5m2_float8",
@@ -244,8 +272,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         accumulator_dtype="float32",
         model_dtype="float16",
     ),
-    "fp16_max_calibration": PerTensorQuantize(
-        name="fp16_max_calibration",
+    MLCQuantization.fp16_max_calibration: PerTensorQuantize(
+        name=MLCQuantization.fp16_max_calibration,
         kind="per-tensor-quant",
         activation_dtype="float16",
         weight_dtype="float16",


### PR DESCRIPTION
Eliminate possibility of typos in quant strings. Can use type `MLCQuantization` in places only valid quantization strings are expected.