### PR TITLE
Remove the TVM submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
-[submodule "3rdparty/tvm"]
-	path = 3rdparty/tvm
-	url = https://github.com/mlc-ai/relax.git


### PR DESCRIPTION
Right now in CI, every time we `git pull` the OLLM repository recursively, we have to checkout a version of TVM (and all it's submodules) twice, once in `ollm/deps/tvm` and the second in `ollm/deps/mlc-llm/3rdparty/tvm`. Since we're not using the latter, I propose removing it here.

I assume this should be fine since we aren't using mlc-llm compiled bits, but would be good for someone to confirm.

Also, this time is non-trivial: it takes about a minute each time our github runners need to `actions/checkout` OLLM recursively. And < 10 seconds without recursive checkout.